### PR TITLE
Add rotation indicator

### DIFF
--- a/src/components/Controls/FactCard.tsx
+++ b/src/components/Controls/FactCard.tsx
@@ -1,7 +1,7 @@
 import { Grid, Group, Paper, Stack, Text } from '@mantine/core';
 import { CelestialBodyState } from '../../lib/types.ts';
 import { Fragment } from 'react';
-import { celestialBodyTypeName, humanTimeUnits, pluralize } from '../../lib/utils.ts';
+import { celestialBodyTypeName, humanDistanceUnits, humanTimeUnits, pluralize } from '../../lib/utils.ts';
 import { magnitude, orbitalPeriod } from '../../lib/physics.ts';
 import { SOL } from '../../lib/constants.ts';
 
@@ -12,11 +12,12 @@ export function FactCard({ body }: Props) {
   // TODO: period for non-sun-orbiting bodies? requires knowing the parent's mass
   const period = orbitalPeriod(body.semiMajorAxis, SOL.mass);
   const [periodTime, periodUnits] = humanTimeUnits(period);
+  const [axisValue, axisUnits] = humanDistanceUnits(body.semiMajorAxis);
   const satellites = body.satellites.map(({ name }) => name);
   const facts: Array<{ label: string; value: string }> = [
     { label: 'mass', value: `${body.mass.toExponential(4)} kg` },
     { label: 'radius', value: `${(body.radius / 1e3).toLocaleString()} km` },
-    { label: 'semi-major axis', value: `${(body.semiMajorAxis / 1e3).toLocaleString()} km` },
+    { label: 'semi-major axis', value: `${axisValue.toLocaleString()} ${axisUnits}` },
     { label: 'eccentricity', value: body.eccentricity.toLocaleString() },
     { label: 'inclination', value: `${body.inclination.toLocaleString()}º` },
     { label: 'longitude of the ascending node', value: `${body.longitudeAscending.toLocaleString()}º` },

--- a/src/components/Controls/GeneralControls.tsx
+++ b/src/components/Controls/GeneralControls.tsx
@@ -53,14 +53,16 @@ export function GeneralControls({ state, updateState, reset }: Props) {
           </Tooltip>
         </Menu.Target>
         <Menu.Dropdown>
-          {(['sun', 'planet', 'moon', 'asteroid', 'trans-neptunian-object'] as Array<CelestialBodyType>).map(type => (
-            <Menu.Item key={type} onClick={() => toggleVisibleType(type)}>
-              <Group gap="xs" align="center">
-                {state.visibleTypes.has(type) ? <IconCircleFilled size={14} /> : <IconCircle size={14} />}
-                {celestialBodyTypeName(type)}
-              </Group>
-            </Menu.Item>
-          ))}
+          {(['sun', 'planet', 'moon', 'asteroid', 'trans-neptunian-object', 'belt'] as Array<CelestialBodyType>).map(
+            type => (
+              <Menu.Item key={type} onClick={() => toggleVisibleType(type)}>
+                <Group gap="xs" align="center">
+                  {state.visibleTypes.has(type) ? <IconCircleFilled size={14} /> : <IconCircle size={14} />}
+                  {celestialBodyTypeName(type)}
+                </Group>
+              </Menu.Item>
+            )
+          )}
         </Menu.Dropdown>
       </Menu>
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,6 +16,7 @@ export const SOL2: CelestialBody = {
   trueAnomaly: 0,
   mass: 1.9885e30,
   radius: 6.957e8,
+  siderealRotationPeriod: 609.12 * 60 * 60, // 609 hours at 16º latitude; true period varies by latitude
   color: '#fa0',
   satellites: [
     {
@@ -29,6 +30,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0, // degrees (choose initial position as desired)
       mass: 3.3011e23,
       radius: 2439.7e3,
+      siderealRotationPeriod: 58.6467 * 24 * 60 * 60, // 58 days
       color: '#888',
       satellites: [],
     },
@@ -43,6 +45,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0, // starting at periapsis // TODO: set real values
       mass: 4.8675e24,
       radius: 6051.8e3,
+      siderealRotationPeriod: -243.02 * 24 * 60 * 60, // 243 days; negative for retrograde rotation
       color: '#fe8',
       satellites: [],
     },
@@ -57,6 +60,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0,
       mass: 5.972168e24,
       radius: 6371e3,
+      siderealRotationPeriod: 23 * 60 * 60 + 56 * 60 + 4.1, // 23h 56 m 4.100s
       color: '#3fb',
       satellites: [
         {
@@ -70,6 +74,7 @@ export const SOL2: CelestialBody = {
           trueAnomaly: 0,
           mass: 7.342e22,
           radius: 1737.4e3,
+          siderealRotationPeriod: 27.321661 * 24 * 60 * 60,
           color: DEFAULT_MOON_COLOR,
           satellites: [],
         },
@@ -100,6 +105,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0,
       mass: 6.4171e23,
       radius: 3389.5e3,
+      siderealRotationPeriod: 24 * 60 * 60 + 37 * 60 + 22.66, // 24 hr 37 min 22.66 sec
       color: '#f53',
       satellites: [
         {
@@ -215,6 +221,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0,
       mass: 1.8982e27,
       radius: 69911e3,
+      siderealRotationPeriod: 9 * 60 * 60 + 55 * 60 + 30, // 9 hr 55 min 30 sec
       color: '#fa2',
       satellites: [
         {
@@ -286,6 +293,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0,
       mass: 5.6834e26,
       radius: 58232e3,
+      siderealRotationPeriod: 10 * 60 * 60 + 32 * 60 + 35, // 10 hr 32 min 35 sec
       color: '#faa',
       satellites: [
         {
@@ -399,6 +407,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0,
       mass: 8.681e25,
       radius: 25362e3,
+      siderealRotationPeriod: -17 * 60 * 60 + 14 * 60 + 24, // -17 hr 14 min 24 sec
       color: '#fec',
       satellites: [], // TODO
     },
@@ -413,6 +422,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0,
       mass: 1.02409e26,
       radius: 24622e3,
+      siderealRotationPeriod: 16 * 60 * 60 + 6.6 * 60, // 16 hr 6.6 min
       color: '#2bc',
       satellites: [], // TODO
     },
@@ -427,6 +437,7 @@ export const SOL2: CelestialBody = {
       trueAnomaly: 0,
       mass: 1.3025e22,
       radius: 1188.3e3,
+      siderealRotationPeriod: 6 * 24 * 60 * 60 + 9 * 60 * 60 + 17.6 * 60, // - 6 days 9 hr 17.6 min (sideways)
       color: '#ddd',
       satellites: [
         {
@@ -440,6 +451,7 @@ export const SOL2: CelestialBody = {
           trueAnomaly: 0,
           mass: 1.586e21,
           radius: 606e3,
+          siderealRotationPeriod: 6 * 24 * 60 * 60 + 9 * 60 * 60 + 17 * 60 + 35.89, // mutually tidally locked w/ pluto
           color: DEFAULT_MOON_COLOR,
           satellites: [],
         },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -508,8 +508,6 @@ export const SOL = {
 };
 export const ASTEROID_BELT = { min: 2.2 * AU, max: 3.2 * AU };
 export const KUIPER_BELT = { min: 30 * AU, max: 55 * AU };
-// TODO: not quite spherical; really should be modeled as an ellipse, teardrop, comet tail, something of the sort
-export const HELIOSPHERE_TERMINATION_SHOCK = { min: 75 * AU, max: 90 * AU };
 
 function getCelestialBodyNames(body: CelestialBody): Array<string> {
   return [body.name, ...body.satellites.flatMap(b => getCelestialBodyNames(b))];

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -506,6 +506,10 @@ export const SOL = {
   // satellites: SOL2.satellites.filter(({ type }) => type === 'sun' || type === 'planet'),
   // satellites: SOL2.satellites.filter(({ name }) => name === 'Mercury'),
 };
+export const ASTEROID_BELT = { min: 2.2 * AU, max: 3.2 * AU };
+export const KUIPER_BELT = { min: 30 * AU, max: 55 * AU };
+// TODO: not quite spherical; really should be modeled as an ellipse, teardrop, comet tail, something of the sort
+export const HELIOSPHERE_TERMINATION_SHOCK = { min: 75 * AU, max: 90 * AU };
 
 function getCelestialBodyNames(body: CelestialBody): Array<string> {
   return [body.name, ...body.satellites.flatMap(b => getCelestialBodyNames(b))];

--- a/src/lib/draw.ts
+++ b/src/lib/draw.ts
@@ -24,16 +24,7 @@ export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, sy
   const [centerOffsetXm, centerOffsetYm] = centerBody?.position ?? [0, 0];
   const [offsetXm, offsetYm] = [panOffsetXm - centerOffsetXm, panOffsetYm - centerOffsetYm];
 
-  function drawBody({
-    name,
-    position,
-    radius,
-    color,
-    satellites,
-    type,
-    rotation,
-    siderealRotationPeriod,
-  }: CelestialBodyState) {
+  function drawBody({ name, position, radius, color, satellites, type, ...body }: CelestialBodyState) {
     if (!visibleTypes.has(type)) {
       return;
     }
@@ -48,8 +39,8 @@ export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, sy
     ctx.fillStyle = color;
     ctx.fill();
     ctx.beginPath();
-    if (siderealRotationPeriod != null) {
-      const rotationOffset = degreesToRadians(rotation);
+    if (body.siderealRotationPeriod != null) {
+      const rotationOffset = degreesToRadians(body.rotation);
       ctx.arc(positionXpx, positionYpx, radiusScaledPx, rotationOffset - Math.PI / 32, rotationOffset + Math.PI / 32);
       ctx.lineTo(positionXpx, positionYpx);
       ctx.fillStyle = 'black';
@@ -66,9 +57,11 @@ export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, sy
     drawOrbitalEllipse(ctx, body, [canvasWidthPx, canvasHeightPx], offset, metersPerPx, 0.5);
   }
 
-  [ASTEROID_BELT, KUIPER_BELT].forEach(({ min, max }) => {
-    drawBelt(ctx, [min, max], [canvasWidthPx, canvasHeightPx], [offsetXm, offsetYm], metersPerPx);
-  });
+  if (visibleTypes.has('belt')) {
+    [ASTEROID_BELT, KUIPER_BELT].forEach(({ min, max }) => {
+      drawBelt(ctx, [min, max], [canvasWidthPx, canvasHeightPx], [offsetXm, offsetYm], metersPerPx);
+    });
+  }
 
   const hoverBody = hover != null ? findCelestialBody(systemState, hover) : undefined;
   if (hoverBody != null) {

--- a/src/lib/draw.ts
+++ b/src/lib/draw.ts
@@ -1,6 +1,6 @@
 import { CelestialBodyState, Point2 } from './types.ts';
 import { AppState } from './state.ts';
-import { ASTEROID_BELT, findCelestialBody, HELIOSPHERE_TERMINATION_SHOCK, KUIPER_BELT } from './constants.ts';
+import { ASTEROID_BELT, findCelestialBody, KUIPER_BELT } from './constants.ts';
 import { degreesToRadians, orbitalEllipseAtTheta } from './physics.ts';
 
 export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, systemState: CelestialBodyState) {
@@ -66,7 +66,7 @@ export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, sy
     drawOrbitalEllipse(ctx, body, [canvasWidthPx, canvasHeightPx], offset, metersPerPx, 0.5);
   }
 
-  [ASTEROID_BELT, KUIPER_BELT, HELIOSPHERE_TERMINATION_SHOCK].forEach(({ min, max }) => {
+  [ASTEROID_BELT, KUIPER_BELT].forEach(({ min, max }) => {
     drawBelt(ctx, [min, max], [canvasWidthPx, canvasHeightPx], [offsetXm, offsetYm], metersPerPx);
   });
 
@@ -95,8 +95,8 @@ function drawBelt(
   const maxRad = max / metersPerPx + fadePx;
   const gradient = ctx.createRadialGradient(...centerPx, minRad, ...centerPx, maxRad);
   gradient.addColorStop(0, 'rgba(255, 255, 255, 0)');
-  gradient.addColorStop(0.2, 'rgba(255, 255, 255, 0.1)');
-  gradient.addColorStop(0.8, 'rgba(255, 255, 255, 0.1)');
+  gradient.addColorStop(0.2, 'rgba(255, 255, 255, 0.05)');
+  gradient.addColorStop(0.8, 'rgba(255, 255, 255, 0.05)');
   gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
   ctx.beginPath();
   ctx.arc(...centerPx, minRad, 0, Math.PI * 2, true);

--- a/src/lib/draw.ts
+++ b/src/lib/draw.ts
@@ -1,4 +1,4 @@
-import { CelestialBodyState } from './types.ts';
+import { CelestialBodyState, Point2 } from './types.ts';
 import { AppState } from './state.ts';
 import { ASTEROID_BELT, findCelestialBody, HELIOSPHERE_TERMINATION_SHOCK, KUIPER_BELT } from './constants.ts';
 import { degreesToRadians, orbitalEllipseAtTheta } from './physics.ts';
@@ -62,7 +62,7 @@ export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, sy
       return;
     }
     body.satellites.forEach(child => drawOrbit(body, child));
-    const offset: [number, number] = [(parent?.position?.[0] ?? 0) + offsetXm, (parent?.position?.[1] ?? 0) + offsetYm];
+    const offset: Point2 = [(parent?.position?.[0] ?? 0) + offsetXm, (parent?.position?.[1] ?? 0) + offsetYm];
     drawOrbitalEllipse(ctx, body, [canvasWidthPx, canvasHeightPx], offset, metersPerPx, 0.5);
   }
 
@@ -84,26 +84,20 @@ export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, sy
 
 function drawBelt(
   ctx: CanvasRenderingContext2D,
-  [min, max]: [number, number],
-  [canvasWidthPx, canvasHeightPx]: [number, number],
-  [offsetXm, offsetYm]: [number, number],
+  [min, max]: Point2,
+  [canvasWidthPx, canvasHeightPx]: Point2,
+  [offsetXm, offsetYm]: Point2,
   metersPerPx: number
 ) {
   const fadePx = (max - min) / 8 / metersPerPx;
-  const centerPx: [number, number] = [
-    canvasWidthPx / 2 + offsetXm / metersPerPx,
-    canvasHeightPx / 2 + offsetYm / metersPerPx,
-  ];
+  const centerPx: Point2 = [canvasWidthPx / 2 + offsetXm / metersPerPx, canvasHeightPx / 2 + offsetYm / metersPerPx];
   const minRad = min / metersPerPx - fadePx;
   const maxRad = max / metersPerPx + fadePx;
   const gradient = ctx.createRadialGradient(...centerPx, minRad, ...centerPx, maxRad);
-
-  // Define color stops for the gradient
-  gradient.addColorStop(0, 'rgba(255, 255, 255, 0)'); // Inner edge (slightly visible)
-  gradient.addColorStop(0.2, 'rgba(255, 255, 255, 0.1)'); // Near outer edge (fading)
-  gradient.addColorStop(0.8, 'rgba(255, 255, 255, 0.1)'); // Near outer edge (fading)
-  gradient.addColorStop(1, 'rgba(255, 255, 255, 0)'); // Fully transparent at the edge
-
+  gradient.addColorStop(0, 'rgba(255, 255, 255, 0)');
+  gradient.addColorStop(0.2, 'rgba(255, 255, 255, 0.1)');
+  gradient.addColorStop(0.8, 'rgba(255, 255, 255, 0.1)');
+  gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
   ctx.beginPath();
   ctx.arc(...centerPx, minRad, 0, Math.PI * 2, true);
   ctx.arc(...centerPx, maxRad, 0, Math.PI * 2);
@@ -114,12 +108,12 @@ function drawBelt(
 function drawOrbitalEllipse(
   ctx: CanvasRenderingContext2D,
   body: CelestialBodyState,
-  [canvasWidthPx, canvasHeightPx]: [number, number],
-  [offsetXm, offsetYm]: [number, number],
+  [canvasWidthPx, canvasHeightPx]: Point2,
+  [offsetXm, offsetYm]: Point2,
   metersPerPx: number,
   lineWidth = 1
 ) {
-  function toPx(xM: number, yM: number): [number, number] {
+  function toPx(xM: number, yM: number): Point2 {
     return [canvasWidthPx / 2 + (xM + offsetXm) / metersPerPx, canvasHeightPx / 2 + (yM + offsetYm) / metersPerPx];
   }
   const steps = 360; // number of segments to approximate the ellipse

--- a/src/lib/draw.ts
+++ b/src/lib/draw.ts
@@ -1,7 +1,7 @@
 import { CelestialBodyState } from './types.ts';
 import { AppState } from './state.ts';
 import { findCelestialBody } from './constants.ts';
-import { orbitalEllipseAtTheta } from './physics.ts';
+import { degreesToRadians, orbitalEllipseAtTheta } from './physics.ts';
 
 export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, systemState: CelestialBodyState) {
   const {
@@ -24,7 +24,16 @@ export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, sy
   const [centerOffsetXm, centerOffsetYm] = centerBody?.position ?? [0, 0];
   const [offsetXm, offsetYm] = [panOffsetXm - centerOffsetXm, panOffsetYm - centerOffsetYm];
 
-  function drawBody({ name, position, radius, color, satellites, type }: CelestialBodyState) {
+  function drawBody({
+    name,
+    position,
+    radius,
+    color,
+    satellites,
+    type,
+    rotation,
+    siderealRotationPeriod,
+  }: CelestialBodyState) {
     if (!visibleTypes.has(type)) {
       return;
     }
@@ -38,6 +47,14 @@ export function drawBodies(ctx: CanvasRenderingContext2D, appState: AppState, sy
     ctx.arc(positionXpx, positionYpx, radiusScaledPx, 0, Math.PI * 2);
     ctx.fillStyle = color;
     ctx.fill();
+    ctx.beginPath();
+    if (siderealRotationPeriod != null) {
+      const rotationOffset = degreesToRadians(rotation);
+      ctx.arc(positionXpx, positionYpx, radiusScaledPx, rotationOffset - Math.PI / 32, rotationOffset + Math.PI / 32);
+      ctx.lineTo(positionXpx, positionYpx);
+      ctx.fillStyle = 'black';
+      ctx.fill();
+    }
   }
 
   function drawOrbit(parent: CelestialBodyState | null, body: CelestialBodyState) {

--- a/src/lib/physics.ts
+++ b/src/lib/physics.ts
@@ -141,7 +141,6 @@ export function getInitialState(parentState: CelestialBodyState | null, child: C
     const { position, velocity } = keplerianToCartesian(child, G * parentState.mass);
     childCartesian = { position: add3(parentState.position, position), velocity: add3(parentState.velocity, velocity) };
   }
-  // TODO: initial rotation?
   const childState: CelestialBodyState = { ...child, ...childCartesian, rotation: 0, satellites: [] }; // satellites to be replaced
   const satellites = child.satellites.map(grandchild => getInitialState(childState, grandchild));
   return { ...childState, satellites };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,10 +19,16 @@ export type CelestialBody = KeplerianElements & {
   name: string;
   mass: number; // kg
   radius: number; // m
+  // TODO: initial rotation?
+  // TODO: axis of rotation?
+  siderealRotationPeriod?: number; // seconds // TODO: required?
   color: `#${string}`; // hex
   satellites: Array<CelestialBody>; // keplerian elements in reference to parent body
   type: CelestialBodyType;
 };
 
 export type CelestialBodyState = Omit<CelestialBody, 'satellites'> &
-  CartesianState & { satellites: Array<CelestialBodyState> };
+  CartesianState & {
+    rotation: number; // degrees
+    satellites: Array<CelestialBodyState>;
+  };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,7 +21,7 @@ export type CelestialBody = KeplerianElements & {
   radius: number; // m
   // TODO: initial rotation?
   // TODO: axis of rotation?
-  siderealRotationPeriod?: number; // seconds // TODO: required?
+  siderealRotationPeriod?: number; // seconds, leave empty to omit spin indicator
   color: `#${string}`; // hex
   satellites: Array<CelestialBody>; // keplerian elements in reference to parent body
   type: CelestialBodyType;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,7 +14,7 @@ export type KeplerianElements = {
   trueAnomaly: number; // degrees
 };
 
-export type CelestialBodyType = 'sun' | 'planet' | 'moon' | 'asteroid' | 'trans-neptunian-object';
+export type CelestialBodyType = 'sun' | 'planet' | 'moon' | 'asteroid' | 'trans-neptunian-object' | 'belt';
 export type CelestialBody = KeplerianElements & {
   name: string;
   mass: number; // kg

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,5 +41,7 @@ export function celestialBodyTypeName(type: CelestialBodyType) {
       return 'Asteroid';
     case 'trans-neptunian-object':
       return 'TNO';
+    case 'belt':
+      return 'Belt';
   }
 }


### PR DESCRIPTION
Populate with `siderealRotationPeriod` (optional) and display a rotation indicator when present. Still need to add the period value to a few bodies, and set additional values like initial rotation (in the same vein as setting true anomaly, which is still a TODO) and rotation axis (some bodies are e.g. on their side).

Also add a toggle to visualize the asteroid and Kuiper belts.