### PR TITLE
Store generated `/api/facts` responses in blob store

### DIFF
--- a/functions/facts.ts
+++ b/functions/facts.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { getStore, Store } from '@netlify/blobs';
 
 async function getWikidataId(search: string): Promise<string | undefined> {
   const baseUrl = 'https://www.wikidata.org/w/api.php';
@@ -150,8 +151,7 @@ I've collected this data from Wikidata to help you provide this information:
 ${wikidataInfoAsCsv(wikidataInfo)}
 \`\`\``;
 
-  console.log(prompt);
-  const model = 'claude-3-5-haiku-20241022'; // 'claude-3-5-haiku-20241022';
+  const model = 'claude-3-5-haiku-20241022'; // 'claude-3-haiku-20240307';
   const stream = await client.messages.stream({
     model,
     system,
@@ -179,18 +179,46 @@ ${wikidataInfoAsCsv(wikidataInfo)}
   });
 }
 
-// TODO: write facts to blob store, try fetching, regenerate only if missing
+async function storeResponse(store: Store, key: string, stream: ReadableStream) {
+  const reader = stream.getReader();
+  let finalResult = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      finalResult += new TextDecoder().decode(value);
+    }
+
+    await store.set(key, finalResult);
+  } catch (error) {
+    console.error('Error processing stream:', error);
+  }
+}
+
 export default async function handle(request: Request) {
   const params = new URL(request.url).searchParams;
   const search = params.get('search');
+  const responseHeaders = {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  };
+
+  const store = getStore('facts');
+  const stored = await store.get(search);
+  if (stored != null) {
+    // TODO: fake token generation on the way out?
+    return new Response(stored, { headers: responseHeaders });
+  }
+
   const id = await getWikidataId(search);
   const info = await getWikidataInfo(id);
   const stream = await formatWithClaude(search, info);
-  return new Response(stream, {
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-    },
-  });
+  const [streamForResponse, streamForStore] = stream.tee();
+
+  // Process the cache stream in the background
+  storeResponse(store, search, streamForStore);
+
+  return new Response(streamForResponse, { headers: responseHeaders });
 }

--- a/functions/facts.ts
+++ b/functions/facts.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { getStore, Store } from '@netlify/blobs';
+import { AnthropicModel } from '../src/lib/llm';
 
 async function getWikidataId(search: string): Promise<string | undefined> {
   const baseUrl = 'https://www.wikidata.org/w/api.php';
@@ -151,9 +152,8 @@ I've collected this data from Wikidata to help you provide this information:
 ${wikidataInfoAsCsv(wikidataInfo)}
 \`\`\``;
 
-  const model = 'claude-3-5-haiku-20241022'; // 'claude-3-haiku-20240307';
   const stream = await client.messages.stream({
-    model,
+    model: AnthropicModel.CLAUDE_3_5_SONNET,
     system,
     messages: [{ role: 'user', content: prompt }],
     max_tokens: 1024,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@anthropic-ai/sdk": "^0.33.1",
     "@mantine/core": "^7.14.3",
     "@mantine/hooks": "^7.14.3",
+    "@netlify/blobs": "^8.1.0",
     "@netlify/functions": "^3.0.0",
     "@tabler/icons-react": "^3.24.0",
     "@tanstack/react-query": "^5.62.8",

--- a/src/components/Controls/FocusControls.tsx
+++ b/src/components/Controls/FocusControls.tsx
@@ -40,7 +40,7 @@ export function FocusControls({ hover, center, updateState, systemState }: Props
         </Menu.Dropdown>
       </Menu>
 
-      <Transition mounted={focusBody != null} transition="slide-right" duration={400} timingFunction="ease">
+      <Transition mounted={focusBody != null} transition="slide-right" duration={200} timingFunction="ease">
         {styles => <Box style={styles}>{focusBody != null && <FactCard body={focusBody} />}</Box>}
       </Transition>
     </Stack>

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,0 +1,5 @@
+export enum AnthropicModel {
+  CLAUDE_3_HAIKU = 'claude-3-haiku-20240307',
+  CLAUDE_3_5_HAIKU = 'claude-3-5-haiku-20241022',
+  CLAUDE_3_5_SONNET = 'claude-3-5-sonnet-20241022',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,7 +935,7 @@
   resolved "https://registry.yarnpkg.com/@netlify/binary-info/-/binary-info-1.0.0.tgz#cd0d86fb783fb03e52067f0cd284865e57be86c8"
   integrity sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw==
 
-"@netlify/blobs@8.1.0":
+"@netlify/blobs@8.1.0", "@netlify/blobs@^8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@netlify/blobs/-/blobs-8.1.0.tgz#b870b7c90c731a787eab550704593222af8222af"
   integrity sha512-9hIbusvAZjSGBJ42OyFC2AxsEph1LuKQahMWFcPGEIsOqIYHhMRkYA7wSUMhH7naydjNmllpcp3pJLOK4RhFaQ==


### PR DESCRIPTION
No need to regenerate every time (expensive); store the responses instead and check the blob store before generating.