### PR TITLE
Add asteroids from SBDB as sub-menu on Asteroid Belt fact sheet

### DIFF
--- a/src/components/Controls/AddSmallBodyModal.tsx
+++ b/src/components/Controls/AddSmallBodyModal.tsx
@@ -2,17 +2,21 @@ import { useEffect, useMemo } from 'react';
 import { useSmallBodies } from '../../hooks/useSmallBodies.ts';
 import {
   ActionIcon,
+  Box,
   Checkbox,
+  Divider,
   Group,
-  Popover,
+  Modal,
+  Paper,
   RenderTreeNodePayload,
   Text,
+  Title,
   Tree,
   TreeNodeData,
   useTree,
 } from '@mantine/core';
-import { IconChevronDown, IconSpherePlus } from '@tabler/icons-react';
-import { AppStateControlProps, iconSize } from './constants.ts';
+import { IconChevronDown, IconX } from '@tabler/icons-react';
+import { AppStateControlProps } from './constants.ts';
 import { CelestialBody, CelestialBodyType } from '../../lib/types.ts';
 import { notNullish } from '../../lib/utils.ts';
 import { UseQueryResult } from '@tanstack/react-query';
@@ -533,10 +537,12 @@ const treeData = bodies.reduce<Array<TreeNodeData>>((acc, name, i) => {
 }, []);
 
 type Props = Pick<AppStateControlProps, 'state'> & {
+  isOpen: boolean;
+  onClose: () => void;
   addBody: (body: CelestialBody) => void;
   removeBody: (name: string) => void;
 };
-export function AddSmallBodyMenu({ state, addBody, removeBody }: Props) {
+export function AddSmallBodyModal({ state, isOpen, onClose, addBody, removeBody }: Props) {
   const initialCheckedState = useMemo(() => {
     const names = state.bodies.filter(({ type }) => isSmallBody(type)).map(({ name }) => name);
     const treeDataFlat = treeData.flatMap(({ children }) => children ?? []);
@@ -594,17 +600,27 @@ export function AddSmallBodyMenu({ state, addBody, removeBody }: Props) {
 
   // TODO: add search/filter box
   return (
-    <Popover position="top" offset={0}>
-      <Popover.Target>
-        <ActionIcon>
-          <IconSpherePlus size={iconSize} />
-        </ActionIcon>
-      </Popover.Target>
-
-      <Popover.Dropdown p={8} miw={200} mah={window.innerHeight - 150} style={{ overflow: 'auto' }}>
-        <Tree tree={tree} data={treeData} levelOffset={23} expandOnClick={false} renderNode={renderTreeNode} />
-      </Popover.Dropdown>
-    </Popover>
+    <Modal
+      size="md"
+      centered
+      opened={isOpen}
+      onClose={onClose}
+      withCloseButton={false}
+      styles={{ body: { padding: 0 } }}
+    >
+      <Paper bg="black" withBorder style={{ overflow: 'hidden' }}>
+        <Group p="md" gap="xs" justify="space-between" wrap="nowrap">
+          <Title order={5}>Add Asteroids from JPL Small Body Database</Title>
+          <ActionIcon onClick={onClose}>
+            <IconX color="var(--mantine-color-gray-light-color)" size={20} />
+          </ActionIcon>
+        </Group>
+        <Divider />
+        <Box p="md" mah="calc(100dvh - 180px)" style={{ overflow: 'auto' }}>
+          <Tree tree={tree} data={treeData} levelOffset={23} expandOnClick={false} renderNode={renderTreeNode} />
+        </Box>
+      </Paper>
+    </Modal>
   );
 }
 

--- a/src/components/Controls/AddSmallBodyModal.tsx
+++ b/src/components/Controls/AddSmallBodyModal.tsx
@@ -599,6 +599,8 @@ export function AddSmallBodyModal({ state, isOpen, onClose, addBody, removeBody 
   }
 
   // TODO: add search/filter box
+  // TODO: not convinced that a tree is the right approach here. Ideally this is an ~infinite scrolling omnibox,
+  //  dynamically loading the next N names from a function (where they are hardcoded)
   return (
     <Modal
       size="md"

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -3,17 +3,14 @@ import { GeneralControls } from './GeneralControls.tsx';
 import { TimeControls } from './TimeControls.tsx';
 import { ScaleControls } from './ScaleControls.tsx';
 import { AppStateControlProps } from './constants.ts';
-import { CelestialBody } from '../../lib/types.ts';
 import { useIsSmallDisplay } from '../../hooks/useIsSmallDisplay.ts';
 
 const pad = 10;
 
 type Props = AppStateControlProps & {
-  addBody: (body: CelestialBody) => void;
-  removeBody: (name: string) => void;
   reset: () => void;
 };
-export function Controls({ state, updateState, addBody, removeBody, reset }: Props) {
+export function Controls({ state, updateState, reset }: Props) {
   const isSmallDisplay = useIsSmallDisplay();
   return (
     <>
@@ -26,13 +23,7 @@ export function Controls({ state, updateState, addBody, removeBody, reset }: Pro
         bottom={pad}
         {...(isSmallDisplay ? { right: pad } : { left: '50%', style: { transform: 'translate(-50%, 0)' } })}
       >
-        <GeneralControls
-          state={state}
-          updateState={updateState}
-          addBody={addBody}
-          removeBody={removeBody}
-          reset={reset}
-        />
+        <GeneralControls state={state} updateState={updateState} reset={reset} />
       </Box>
 
       <Box pos="absolute" right={pad} {...(isSmallDisplay ? { top: pad } : { bottom: pad })}>

--- a/src/components/Controls/GeneralControls.tsx
+++ b/src/components/Controls/GeneralControls.tsx
@@ -2,7 +2,6 @@ import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import { IconCircle, IconCircleDot, IconRestore, IconTagMinus, IconTagPlus } from '@tabler/icons-react';
 import { AppStateControlProps, buttonGap, iconSize } from './constants.ts';
 import { memo } from 'react';
-import { AddSmallBodyModal } from './AddSmallBodyModal.tsx';
 import { SelectOmnibox } from './SelectOmnibox.tsx';
 import { HelpModalButton } from './HelpModalButton.tsx';
 import { VisibilityControls } from './VisibilityControls.tsx';
@@ -10,26 +9,16 @@ import { VisibilityControls } from './VisibilityControls.tsx';
 type Props = AppStateControlProps & {
   reset: () => void;
 };
-export const GeneralControls = memo(function GeneralControlsComponent({
-  state,
-  updateState,
-  addBody,
-  removeBody,
-  reset,
-}: Props) {
+export const GeneralControls = memo(function GeneralControlsComponent({ state, updateState, reset }: Props) {
   return (
     <Group gap={buttonGap}>
-      {/* TODO: these two controls should be merged, ideally */}
       <SelectOmnibox state={state} updateState={updateState} />
-      <AddSmallBodyModal state={state} addBody={addBody} removeBody={removeBody} />
 
       <Tooltip position="top" label={`${state.drawOrbit ? 'Hide' : 'Show'} Orbits`}>
         <ActionIcon onClick={() => updateState({ drawOrbit: !state.drawOrbit })}>
           {state.drawOrbit ? <IconCircleDot size={iconSize} /> : <IconCircle size={iconSize} />}
         </ActionIcon>
       </Tooltip>
-
-      <VisibilityControls state={state} updateState={updateState} />
 
       <Tooltip position="top" label={`${state.drawLabel ? 'Hide' : 'Show'} Labels`}>
         <ActionIcon onClick={() => updateState({ drawLabel: !state.drawLabel })}>
@@ -44,6 +33,8 @@ export const GeneralControls = memo(function GeneralControlsComponent({
         </ActionIcon>
       </Tooltip>
       */}
+
+      <VisibilityControls state={state} updateState={updateState} />
 
       <Tooltip position="top" label="Reset">
         <ActionIcon onClick={reset}>

--- a/src/components/Controls/GeneralControls.tsx
+++ b/src/components/Controls/GeneralControls.tsx
@@ -1,16 +1,13 @@
 import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import { IconCircle, IconCircleDot, IconRestore, IconTagMinus, IconTagPlus } from '@tabler/icons-react';
-import { CelestialBody } from '../../lib/types.ts';
 import { AppStateControlProps, buttonGap, iconSize } from './constants.ts';
 import { memo } from 'react';
-import { AddSmallBodyMenu } from './AddSmallBodyMenu.tsx';
+import { AddSmallBodyModal } from './AddSmallBodyModal.tsx';
 import { SelectOmnibox } from './SelectOmnibox.tsx';
 import { HelpModalButton } from './HelpModalButton.tsx';
 import { VisibilityControls } from './VisibilityControls.tsx';
 
 type Props = AppStateControlProps & {
-  addBody: (body: CelestialBody) => void;
-  removeBody: (name: string) => void;
   reset: () => void;
 };
 export const GeneralControls = memo(function GeneralControlsComponent({
@@ -24,7 +21,7 @@ export const GeneralControls = memo(function GeneralControlsComponent({
     <Group gap={buttonGap}>
       {/* TODO: these two controls should be merged, ideally */}
       <SelectOmnibox state={state} updateState={updateState} />
-      <AddSmallBodyMenu state={state} addBody={addBody} removeBody={removeBody} />
+      <AddSmallBodyModal state={state} addBody={addBody} removeBody={removeBody} />
 
       <Tooltip position="top" label={`${state.drawOrbit ? 'Hide' : 'Show'} Orbits`}>
         <ActionIcon onClick={() => updateState({ drawOrbit: !state.drawOrbit })}>

--- a/src/components/Controls/HelpModal.tsx
+++ b/src/components/Controls/HelpModal.tsx
@@ -95,14 +95,7 @@ export function HelpModal({ isOpen, onClose, state, updateState }: Props) {
   ));
 
   return (
-    <Modal
-      size="xl"
-      opened={isOpen}
-      onClose={onClose}
-      withCloseButton={false}
-      overlayProps={{ blur: 4, backgroundOpacity: 0 }}
-      transitionProps={{ transition: 'fade' }}
-    >
+    <Modal size="xl" opened={isOpen} onClose={onClose} withCloseButton={false}>
       <Stack
         gap={0}
         fz="sm"

--- a/src/components/FactSheet/AddSmallBodyButton.tsx
+++ b/src/components/FactSheet/AddSmallBodyButton.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@mantine/core';
+import { IconSpherePlus } from '@tabler/icons-react';
+import { iconSize } from '../Controls/constants.ts';
+import { AppState } from '../../lib/state.ts';
+import { AddSmallBodyModal } from '../Controls/AddSmallBodyModal.tsx';
+import { CelestialBody } from '../../lib/types.ts';
+import { useDisclosure } from '@mantine/hooks';
+
+type Props = {
+  state: AppState;
+  addBody: (body: CelestialBody) => void;
+  removeBody: (name: string) => void;
+};
+export function AddSmallBodyButton({ state, addBody, removeBody }: Props) {
+  const [isOpen, { open: onOpen, close: onClose }] = useDisclosure(false);
+
+  return (
+    <>
+      <Button
+        size="xl"
+        fz="xs"
+        color="gray"
+        variant="light"
+        leftSection={<IconSpherePlus size={iconSize} />}
+        onClick={onOpen}
+      >
+        Add Asteroids
+      </Button>
+      <AddSmallBodyModal isOpen={isOpen} onClose={onClose} state={state} addBody={addBody} removeBody={removeBody} />
+    </>
+  );
+}

--- a/src/components/FactSheet/CelestialBodyFactSheet.tsx
+++ b/src/components/FactSheet/CelestialBodyFactSheet.tsx
@@ -16,16 +16,19 @@ import { FactGrid } from './FactGrid.tsx';
 import { FactSheetTitle } from './FactSheetTitle.tsx';
 import { FactSheetSummary } from './FactSheetSummary.tsx';
 import { OrbitalRegimePill } from './OrbitalRegimePill.tsx';
-import { ReactNode } from 'react';
+import { memo, ReactNode } from 'react';
 import { OtherRegimes } from './OtherRegimes.tsx';
 
 type Props = {
   body: CelestialBody;
   bodies: Array<CelestialBody>;
   updateState: (update: Partial<AppState>) => void;
-  width?: number;
 };
-export function CelestialBodyFactSheet({ body, bodies, updateState, width }: Props) {
+export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetComponent({
+  body,
+  bodies,
+  updateState,
+}: Props) {
   const { name, type, mass, radius, elements, rotation } = body;
   const { data: facts, isLoading } = useFactsStream(`${name}+${type}`);
 
@@ -67,7 +70,7 @@ export function CelestialBodyFactSheet({ body, bodies, updateState, width }: Pro
   const galleryUrls = GalleryImages[name] ?? [];
 
   return (
-    <Stack w={width} fz="xs" gap={2} h="100%" style={{ overflow: 'auto' }} flex={1}>
+    <Stack fz="xs" gap={2} h="100%" style={{ overflow: 'auto' }} flex={1}>
       <FactSheetTitle
         title={body.name}
         subTitle={celestialBodyTypeDescription(body)}
@@ -107,7 +110,7 @@ export function CelestialBodyFactSheet({ body, bodies, updateState, width }: Pro
       </Box>
     </Stack>
   );
-}
+});
 
 // TODO: better to have Claude generate facts as structured data
 function factsAsBullets(facts: string | undefined): Array<{ label: string; value: string }> {

--- a/src/components/FactSheet/FactSheet.tsx
+++ b/src/components/FactSheet/FactSheet.tsx
@@ -4,18 +4,33 @@ import { AppState } from '../../lib/state.ts';
 import { memo } from 'react';
 import { OrbitalRegimeFactSheet } from './OrbitalRegimeFactSheet.tsx';
 
+// TODO: there's some pretty serious prop drilling going on here
 type Props = {
   body?: CelestialBody;
   regime?: OrbitalRegime;
-  bodies: Array<CelestialBody>;
+  state: AppState;
   updateState: (update: Partial<AppState>) => void;
-  width?: number;
+  addBody: (body: CelestialBody) => void;
+  removeBody: (name: string) => void;
 };
-export const FactSheet = memo(function FactSheetComponent({ body, regime, bodies, updateState, width }: Props) {
+export const FactSheet = memo(function FactSheetComponent({
+  body,
+  regime,
+  state,
+  updateState,
+  addBody,
+  removeBody,
+}: Props) {
   return body != null ? (
-    <CelestialBodyFactSheet body={body} bodies={bodies} updateState={updateState} width={width} />
+    <CelestialBodyFactSheet body={body} bodies={state.bodies} updateState={updateState} />
   ) : regime != null ? (
-    <OrbitalRegimeFactSheet regime={regime} bodies={bodies} updateState={updateState} width={width} />
+    <OrbitalRegimeFactSheet
+      regime={regime}
+      state={state}
+      updateState={updateState}
+      addBody={addBody}
+      removeBody={removeBody}
+    />
   ) : (
     <></>
   );

--- a/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
+++ b/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
@@ -1,4 +1,4 @@
-import { CelestialBody, OrbitalRegime } from '../../lib/types.ts';
+import { CelestialBody, HeliocentricOrbitalRegime, OrbitalRegime } from '../../lib/types.ts';
 import { AppState } from '../../lib/state.ts';
 import { Box, Stack, Title } from '@mantine/core';
 import { FactSheetTitle } from './FactSheetTitle.tsx';
@@ -7,21 +7,23 @@ import { useMemo } from 'react';
 import { BodyCard } from './BodyCard.tsx';
 import { FactSheetSummary } from './FactSheetSummary.tsx';
 import { OtherRegimes } from './OtherRegimes.tsx';
+import { AddSmallBodyButton } from './AddSmallBodyButton.tsx';
 
 type Props = {
   regime: OrbitalRegime;
-  bodies: Array<CelestialBody>;
+  state: AppState;
   updateState: (update: Partial<AppState>) => void;
-  width?: number;
+  addBody: (body: CelestialBody) => void;
+  removeBody: (name: string) => void;
 };
-export function OrbitalRegimeFactSheet({ regime, bodies, updateState, width }: Props) {
+export function OrbitalRegimeFactSheet({ regime, state, updateState, addBody, removeBody }: Props) {
   const bodiesInRegime = useMemo(
-    () => bodies.filter(body => body.orbitalRegime === regime.name),
-    [regime.name, JSON.stringify(bodies)]
+    () => state.bodies.filter(body => body.orbitalRegime === regime.name),
+    [regime.name, JSON.stringify(state.bodies)]
   );
 
   return (
-    <Stack w={width} fz="xs" gap={2} h="100%" style={{ overflow: 'auto' }} flex={1}>
+    <Stack fz="xs" gap={2} h="100%" style={{ overflow: 'auto' }} flex={1}>
       <FactSheetTitle
         title={regime.name}
         subTitle="Orbital Regime"
@@ -36,6 +38,9 @@ export function OrbitalRegimeFactSheet({ regime, bodies, updateState, width }: P
         {bodiesInRegime.map((body, i) => (
           <BodyCard key={`${body.name}-${i}`} body={body} onClick={() => updateState({ center: body.name })} />
         ))}
+        {regime.name === HeliocentricOrbitalRegime.ASTEROID_BELT && (
+          <AddSmallBodyButton state={state} addBody={addBody} removeBody={removeBody} />
+        )}
       </Stack>
 
       <Box style={{ justifySelf: 'flex-end' }}>

--- a/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
+++ b/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
@@ -17,6 +17,7 @@ type Props = {
   removeBody: (name: string) => void;
 };
 export function OrbitalRegimeFactSheet({ regime, state, updateState, addBody, removeBody }: Props) {
+  const isAsteroidBelt = regime.name === HeliocentricOrbitalRegime.ASTEROID_BELT;
   const bodiesInRegime = useMemo(
     () => state.bodies.filter(body => body.orbitalRegime === regime.name),
     [regime.name, JSON.stringify(state.bodies)]
@@ -34,13 +35,11 @@ export function OrbitalRegimeFactSheet({ regime, state, updateState, addBody, re
       <FactSheetSummary obj={regime} />
 
       <Stack p="md" gap="xs" flex={1}>
-        <Title order={5}>Celestial Bodies</Title>
+        <Title order={5}>{isAsteroidBelt ? 'Asteroids' : 'Celestial Bodies'}</Title>
         {bodiesInRegime.map((body, i) => (
           <BodyCard key={`${body.name}-${i}`} body={body} onClick={() => updateState({ center: body.name })} />
         ))}
-        {regime.name === HeliocentricOrbitalRegime.ASTEROID_BELT && (
-          <AddSmallBodyButton state={state} addBody={addBody} removeBody={removeBody} />
-        )}
+        {isAsteroidBelt && <AddSmallBodyButton state={state} addBody={addBody} removeBody={removeBody} />}
       </Stack>
 
       <Box style={{ justifySelf: 'flex-end' }}>

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -95,17 +95,12 @@ export function SolarSystem() {
           ref={model.canvasRef}
           style={{ height: '100%', width: '100%', position: 'absolute', pointerEvents: 'none' }}
         />
-        <Controls
-          state={appState}
-          updateState={updateState}
-          addBody={addBody}
-          removeBody={removeBody}
-          reset={resetState}
-        />
+        <Controls state={appState} updateState={updateState} reset={resetState} />
       </Box>
       {(focusBody != null || focusRegime != null) && (
         <Box
           h={isSmallDisplay ? '50dvh' : '100dvh'}
+          w={isSmallDisplay ? undefined : 600}
           style={{
             borderLeft: isSmallDisplay ? undefined : `1px solid ${focusBody?.color ?? DEFAULT_ASTEROID_COLOR}`,
             borderTop: isSmallDisplay ? `1px solid ${focusBody?.color ?? DEFAULT_ASTEROID_COLOR}` : undefined,
@@ -115,9 +110,10 @@ export function SolarSystem() {
             key={focusBody?.name ?? focusRegime?.name} // ensure that the component is rerendered when focus changes
             body={focusBody}
             regime={focusRegime}
-            bodies={appState.bodies}
+            state={appState}
             updateState={updateState}
-            width={isSmallDisplay ? undefined : 600}
+            addBody={addBody}
+            removeBody={removeBody}
           />
         </Box>
       )}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Button, createTheme, Paper, Tooltip } from '@mantine/core';
+import { ActionIcon, Button, createTheme, Modal, Paper, Tooltip } from '@mantine/core';
 
 export const theme = createTheme({
   primaryColor: 'blue',
@@ -14,5 +14,11 @@ export const theme = createTheme({
     }),
     Tooltip: Tooltip.extend({ defaultProps: { fz: 'xs', px: 6, py: 2, openDelay: 400 } }),
     Paper: Paper.extend({ defaultProps: { bg: 'transparent', style: { backdropFilter: 'blur(4px)' } } }),
+    Modal: Modal.extend({
+      defaultProps: {
+        overlayProps: { blur: 4, backgroundOpacity: 0 },
+        transitionProps: { transition: 'fade' },
+      },
+    }),
   },
 });


### PR DESCRIPTION
Refactor unblocked by #49. Now the SBDB menu is a modal that is opened from the Asteroid Belt fact sheet. There's still a lot of room for improvement here, but this is a start.