### PR TITLE
Refactor to split settings/model states

### DIFF
--- a/src/components/Controls/AddSmallBodyModal.tsx
+++ b/src/components/Controls/AddSmallBodyModal.tsx
@@ -16,7 +16,6 @@ import {
   useTree,
 } from '@mantine/core';
 import { IconChevronDown, IconX } from '@tabler/icons-react';
-import { AppStateControlProps } from './constants.ts';
 import { CelestialBody, CelestialBodyType } from '../../lib/types.ts';
 import { notNullish } from '../../lib/utils.ts';
 import { UseQueryResult } from '@tanstack/react-query';
@@ -536,23 +535,24 @@ const treeData = bodies.reduce<Array<TreeNodeData>>((acc, name, i) => {
   return acc;
 }, []);
 
-type Props = Pick<AppStateControlProps, 'state'> & {
+type Props = {
   isOpen: boolean;
   onClose: () => void;
+  bodies: Array<CelestialBody>;
   addBody: (body: CelestialBody) => void;
   removeBody: (name: string) => void;
 };
-export function AddSmallBodyModal({ state, isOpen, onClose, addBody, removeBody }: Props) {
+export function AddSmallBodyModal({ bodies, isOpen, onClose, addBody, removeBody }: Props) {
   const initialCheckedState = useMemo(() => {
-    const names = state.bodies.filter(({ type }) => isSmallBody(type)).map(({ name }) => name);
+    const names = bodies.filter(({ type }) => isSmallBody(type)).map(({ name }) => name);
     const treeDataFlat = treeData.flatMap(({ children }) => children ?? []);
     return treeDataFlat.filter(({ value }) => names.some(name => value.includes(name))).map(({ value }) => value);
-  }, [JSON.stringify(state.bodies)]);
+  }, [JSON.stringify(bodies)]);
 
   const tree = useTree({ initialCheckedState });
 
   // filter out bodies that are already in the state to avoid re-fetching hardcoded bodies from SBDB (e.g. Ceres)
-  const existingBodyNames = new Set(state.bodies.map(({ name }) => name));
+  const existingBodyNames = new Set(bodies.map(({ name }) => name));
   const selectedBodies = tree.checkedState.map(getBodyNameFromNodeValue).filter(name => !existingBodyNames.has(name));
   const smallBodyQueries: Array<UseQueryResult<CelestialBody | null>> = useSmallBodies(selectedBodies);
   const smallBodies: Array<CelestialBody> = smallBodyQueries.map(({ data }) => data).filter(notNullish);

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -2,13 +2,14 @@ import { Box } from '@mantine/core';
 import { GeneralControls } from './GeneralControls.tsx';
 import { TimeControls } from './TimeControls.tsx';
 import { ScaleControls } from './ScaleControls.tsx';
-import { SettingsControlProps } from './constants.ts';
 import { useIsSmallDisplay } from '../../hooks/useIsSmallDisplay.ts';
-import { ModelState } from '../../lib/state.ts';
+import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
 
 const pad = 10;
 
-type Props = SettingsControlProps & {
+type Props = {
+  settings: Settings;
+  updateSettings: UpdateSettings;
   model: ModelState;
   reset: () => void;
 };

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -2,20 +2,22 @@ import { Box } from '@mantine/core';
 import { GeneralControls } from './GeneralControls.tsx';
 import { TimeControls } from './TimeControls.tsx';
 import { ScaleControls } from './ScaleControls.tsx';
-import { AppStateControlProps } from './constants.ts';
+import { SettingsControlProps } from './constants.ts';
 import { useIsSmallDisplay } from '../../hooks/useIsSmallDisplay.ts';
+import { ModelState } from '../../lib/state.ts';
 
 const pad = 10;
 
-type Props = AppStateControlProps & {
+type Props = SettingsControlProps & {
+  model: ModelState;
   reset: () => void;
 };
-export function Controls({ state, updateState, reset }: Props) {
+export function Controls({ settings, updateSettings, model, reset }: Props) {
   const isSmallDisplay = useIsSmallDisplay();
   return (
     <>
       <Box pos="absolute" bottom={pad} left={pad}>
-        <TimeControls state={state} updateState={updateState} />
+        <TimeControls settings={settings} updateSettings={updateSettings} />
       </Box>
 
       <Box
@@ -23,11 +25,11 @@ export function Controls({ state, updateState, reset }: Props) {
         bottom={pad}
         {...(isSmallDisplay ? { right: pad } : { left: '50%', style: { transform: 'translate(-50%, 0)' } })}
       >
-        <GeneralControls state={state} updateState={updateState} reset={reset} />
+        <GeneralControls settings={settings} updateSettings={updateSettings} reset={reset} />
       </Box>
 
       <Box pos="absolute" right={pad} {...(isSmallDisplay ? { top: pad } : { bottom: pad })}>
-        <ScaleControls metersPerPx={state.metersPerPx} vernalEquinox={state.vernalEquinox} />
+        <ScaleControls metersPerPx={model.metersPerPx} vernalEquinox={model.vernalEquinox} />
       </Box>
     </>
   );

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -17,7 +17,7 @@ export function Controls({ settings, updateSettings, model, reset }: Props) {
   return (
     <>
       <Box pos="absolute" bottom={pad} left={pad}>
-        <TimeControls settings={settings} updateSettings={updateSettings} />
+        <TimeControls settings={settings} updateSettings={updateSettings} model={model} />
       </Box>
 
       <Box

--- a/src/components/Controls/DirectionIndicator.tsx
+++ b/src/components/Controls/DirectionIndicator.tsx
@@ -1,9 +1,9 @@
-import { AppState } from '../../lib/state.ts';
+import { ModelState } from '../../lib/state.ts';
 import { buttonGap } from './constants.ts';
 import { Group, Text, Tooltip } from '@mantine/core';
 import { IconArrowRightBar, IconZodiacAries } from '@tabler/icons-react';
 
-type Props = Pick<AppState, 'vernalEquinox'>;
+type Props = Pick<ModelState, 'vernalEquinox'>;
 export function DirectionIndicator({ vernalEquinox }: Props) {
   const iconSize = 20;
   const angle = Number(Math.atan2(vernalEquinox[1], vernalEquinox[0]).toFixed(3));

--- a/src/components/Controls/GeneralControls.tsx
+++ b/src/components/Controls/GeneralControls.tsx
@@ -1,12 +1,15 @@
 import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import { IconCircle, IconCircleDot, IconRestore, IconTagMinus, IconTagPlus } from '@tabler/icons-react';
-import { SettingsControlProps, buttonGap, iconSize } from './constants.ts';
+import { buttonGap, iconSize } from './constants.ts';
 import { memo } from 'react';
 import { SelectOmnibox } from './SelectOmnibox.tsx';
 import { HelpModalButton } from './HelpModalButton.tsx';
 import { VisibilityControls } from './VisibilityControls.tsx';
+import { Settings, UpdateSettings } from '../../lib/state.ts';
 
-type Props = SettingsControlProps & {
+type Props = {
+  settings: Settings;
+  updateSettings: UpdateSettings;
   reset: () => void;
 };
 export const GeneralControls = memo(function GeneralControlsComponent({ settings, updateSettings, reset }: Props) {

--- a/src/components/Controls/GeneralControls.tsx
+++ b/src/components/Controls/GeneralControls.tsx
@@ -1,28 +1,28 @@
 import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import { IconCircle, IconCircleDot, IconRestore, IconTagMinus, IconTagPlus } from '@tabler/icons-react';
-import { AppStateControlProps, buttonGap, iconSize } from './constants.ts';
+import { SettingsControlProps, buttonGap, iconSize } from './constants.ts';
 import { memo } from 'react';
 import { SelectOmnibox } from './SelectOmnibox.tsx';
 import { HelpModalButton } from './HelpModalButton.tsx';
 import { VisibilityControls } from './VisibilityControls.tsx';
 
-type Props = AppStateControlProps & {
+type Props = SettingsControlProps & {
   reset: () => void;
 };
-export const GeneralControls = memo(function GeneralControlsComponent({ state, updateState, reset }: Props) {
+export const GeneralControls = memo(function GeneralControlsComponent({ settings, updateSettings, reset }: Props) {
   return (
     <Group gap={buttonGap}>
-      <SelectOmnibox state={state} updateState={updateState} />
+      <SelectOmnibox settings={settings} updateSettings={updateSettings} />
 
-      <Tooltip position="top" label={`${state.drawOrbit ? 'Hide' : 'Show'} Orbits`}>
-        <ActionIcon onClick={() => updateState({ drawOrbit: !state.drawOrbit })}>
-          {state.drawOrbit ? <IconCircleDot size={iconSize} /> : <IconCircle size={iconSize} />}
+      <Tooltip position="top" label={`${settings.drawOrbit ? 'Hide' : 'Show'} Orbits`}>
+        <ActionIcon onClick={() => updateSettings({ drawOrbit: !settings.drawOrbit })}>
+          {settings.drawOrbit ? <IconCircleDot size={iconSize} /> : <IconCircle size={iconSize} />}
         </ActionIcon>
       </Tooltip>
 
-      <Tooltip position="top" label={`${state.drawLabel ? 'Hide' : 'Show'} Labels`}>
-        <ActionIcon onClick={() => updateState({ drawLabel: !state.drawLabel })}>
-          {state.drawLabel ? <IconTagMinus size={iconSize} /> : <IconTagPlus size={iconSize} />}
+      <Tooltip position="top" label={`${settings.drawLabel ? 'Hide' : 'Show'} Labels`}>
+        <ActionIcon onClick={() => updateSettings({ drawLabel: !settings.drawLabel })}>
+          {settings.drawLabel ? <IconTagMinus size={iconSize} /> : <IconTagPlus size={iconSize} />}
         </ActionIcon>
       </Tooltip>
 
@@ -34,7 +34,7 @@ export const GeneralControls = memo(function GeneralControlsComponent({ state, u
       </Tooltip>
       */}
 
-      <VisibilityControls state={state} updateState={updateState} />
+      <VisibilityControls settings={settings} updateSettings={updateSettings} />
 
       <Tooltip position="top" label="Reset">
         <ActionIcon onClick={reset}>
@@ -42,7 +42,7 @@ export const GeneralControls = memo(function GeneralControlsComponent({ state, u
         </ActionIcon>
       </Tooltip>
 
-      <HelpModalButton state={state} updateState={updateState} />
+      <HelpModalButton settings={settings} updateSettings={updateSettings} />
     </Group>
   );
 });

--- a/src/components/Controls/HelpModal.tsx
+++ b/src/components/Controls/HelpModal.tsx
@@ -30,7 +30,7 @@ import { ReactNode, useMemo } from 'react';
 import { useIsTouchDevice } from '../../hooks/useIsTouchDevice.ts';
 import { useModifierKey } from '../../hooks/useModifierKey.ts';
 import { BodyCard } from '../FactSheet/BodyCard.tsx';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import { useIsSmallDisplay } from '../../hooks/useIsSmallDisplay.ts';
 
@@ -76,17 +76,17 @@ const TOUCH_BULLETS = [
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  state: AppState;
-  updateState: (update: Partial<AppState> | ((prev: AppState) => AppState)) => void;
+  settings: Settings;
+  updateSettings: (update: Partial<Settings> | ((prev: Settings) => Settings)) => void;
 };
-export function HelpModal({ isOpen, onClose, state, updateState }: Props) {
+export function HelpModal({ isOpen, onClose, settings, updateSettings }: Props) {
   const isTouchDevice = useIsTouchDevice();
   const isSmallDisplay = useIsSmallDisplay();
   const modifierKey = useModifierKey();
-  const sampleBodies = useMemo(() => [...state.bodies].sort(() => Math.random() - 0.5).slice(0, 3), []);
+  const sampleBodies = useMemo(() => [...settings.bodies].sort(() => Math.random() - 0.5).slice(0, 3), []);
 
   function onCardClick(body: CelestialBody) {
-    updateState({ center: body.name });
+    updateSettings({ center: body.name });
     onClose();
   }
 

--- a/src/components/Controls/HelpModalButton.tsx
+++ b/src/components/Controls/HelpModalButton.tsx
@@ -1,11 +1,16 @@
 import { ActionIcon, Tooltip } from '@mantine/core';
 import { IconHelp } from '@tabler/icons-react';
-import { SettingsControlProps, iconSize } from './constants.ts';
+import { iconSize } from './constants.ts';
 import { useDisclosure, useLocalStorage } from '@mantine/hooks';
 import { useEffect } from 'react';
 import { HelpModal } from './HelpModal.tsx';
+import { Settings, UpdateSettings } from '../../lib/state.ts';
 
-export function HelpModalButton({ settings, updateSettings }: SettingsControlProps) {
+type Props = {
+  settings: Settings;
+  updateSettings: UpdateSettings;
+};
+export function HelpModalButton({ settings, updateSettings }: Props) {
   const [hasSeenHelpModal, setHasSeenHelpModal] = useLocalStorage({
     key: 'has-seen-help-modal',
     getInitialValueInEffect: false,

--- a/src/components/Controls/HelpModalButton.tsx
+++ b/src/components/Controls/HelpModalButton.tsx
@@ -1,11 +1,11 @@
 import { ActionIcon, Tooltip } from '@mantine/core';
 import { IconHelp } from '@tabler/icons-react';
-import { AppStateControlProps, iconSize } from './constants.ts';
+import { SettingsControlProps, iconSize } from './constants.ts';
 import { useDisclosure, useLocalStorage } from '@mantine/hooks';
 import { useEffect } from 'react';
 import { HelpModal } from './HelpModal.tsx';
 
-export function HelpModalButton({ state, updateState }: AppStateControlProps) {
+export function HelpModalButton({ settings, updateSettings }: SettingsControlProps) {
   const [hasSeenHelpModal, setHasSeenHelpModal] = useLocalStorage({
     key: 'has-seen-help-modal',
     getInitialValueInEffect: false,
@@ -13,12 +13,12 @@ export function HelpModalButton({ state, updateState }: AppStateControlProps) {
   const [isOpen, controls] = useDisclosure(false);
 
   function openHelp() {
-    updateState({ play: false });
+    updateSettings({ play: false });
     controls.open();
   }
 
   function closeHelp() {
-    updateState({ play: true });
+    updateSettings({ play: true });
     controls.close();
     setHasSeenHelpModal('true');
   }
@@ -34,7 +34,7 @@ export function HelpModalButton({ state, updateState }: AppStateControlProps) {
           <IconHelp size={iconSize} />
         </ActionIcon>
       </Tooltip>
-      <HelpModal isOpen={isOpen} onClose={closeHelp} state={state} updateState={updateState} />
+      <HelpModal isOpen={isOpen} onClose={closeHelp} settings={settings} updateSettings={updateSettings} />
     </>
   );
 }

--- a/src/components/Controls/ScaleControls.tsx
+++ b/src/components/Controls/ScaleControls.tsx
@@ -1,11 +1,11 @@
 import { buttonGap } from './constants.ts';
 import { ScaleIndicator } from './ScaleIndicator.tsx';
 import { memo } from 'react';
-import { AppState } from '../../lib/state.ts';
+import { ModelState } from '../../lib/state.ts';
 import { DirectionIndicator } from './DirectionIndicator.tsx';
 import { Group } from '@mantine/core';
 
-type Props = Pick<AppState, 'metersPerPx' | 'vernalEquinox'>;
+type Props = Pick<ModelState, 'metersPerPx' | 'vernalEquinox'>;
 export const ScaleControls = memo(function ScaleControlsComponent({ metersPerPx, vernalEquinox }: Props) {
   return (
     <Group gap={buttonGap} align="flex-end">

--- a/src/components/Controls/ScaleIndicator.tsx
+++ b/src/components/Controls/ScaleIndicator.tsx
@@ -1,9 +1,8 @@
 import { Box, Paper, Stack, Text } from '@mantine/core';
 import { AU } from '../../lib/bodies.ts';
+import { ModelState } from '../../lib/state.ts';
 
-type Props = {
-  metersPerPx: number;
-};
+type Props = Pick<ModelState, 'metersPerPx'>;
 export function ScaleIndicator({ metersPerPx }: Props) {
   let scaleWidthM, scaleDisplay, scaleUnits;
   if (metersPerPx > 0.005 * AU) {

--- a/src/components/Controls/SelectOmnibox.tsx
+++ b/src/components/Controls/SelectOmnibox.tsx
@@ -4,23 +4,23 @@ import { ActionIcon, Box, Group, Kbd, Text, Tooltip } from '@mantine/core';
 import { IconSearch } from '@tabler/icons-react';
 import { Thumbnail } from '../FactSheet/Thumbnail.tsx';
 import styles from './SelectOmnibox.module.css';
-import { AppStateControlProps, iconSize } from './constants.ts';
+import { SettingsControlProps, iconSize } from './constants.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import { celestialBodyTypeDescription } from '../../lib/utils.ts';
 import { useModifierKey } from '../../hooks/useModifierKey.ts';
 import { ORBITAL_REGIMES } from '../../lib/regimes.ts';
 
-export function SelectOmnibox({ state, updateState }: AppStateControlProps) {
+export function SelectOmnibox({ settings, updateSettings }: SettingsControlProps) {
   const [query, setQuery] = useState('');
   const modifierKey = useModifierKey();
 
   function handleSelect(body: CelestialBody) {
-    updateState(prev => ({ ...prev, center: body.name, visibleTypes: new Set([...prev.visibleTypes, body.type]) }));
+    updateSettings(prev => ({ ...prev, center: body.name, visibleTypes: new Set([...prev.visibleTypes, body.type]) }));
   }
 
   const bodyItems = useMemo(
     () =>
-      state.bodies
+      settings.bodies
         .filter(body => query.length === 0 || matchesQuery(body, query))
         .map((body, i) => (
           <Spotlight.Action
@@ -41,7 +41,7 @@ export function SelectOmnibox({ state, updateState }: AppStateControlProps) {
             onClick={() => handleSelect(body)}
           />
         )),
-    [query, JSON.stringify(state.bodies)]
+    [query, JSON.stringify(settings.bodies)]
   );
 
   const regimeItems = useMemo(
@@ -58,7 +58,7 @@ export function SelectOmnibox({ state, updateState }: AppStateControlProps) {
                 Orbital Regime
               </Text>
             }
-            onClick={() => updateState(prev => ({ ...prev, center: name }))}
+            onClick={() => updateSettings(prev => ({ ...prev, center: name }))}
           />
         )),
     [query]

--- a/src/components/Controls/SelectOmnibox.tsx
+++ b/src/components/Controls/SelectOmnibox.tsx
@@ -4,13 +4,18 @@ import { ActionIcon, Box, Group, Kbd, Text, Tooltip } from '@mantine/core';
 import { IconSearch } from '@tabler/icons-react';
 import { Thumbnail } from '../FactSheet/Thumbnail.tsx';
 import styles from './SelectOmnibox.module.css';
-import { SettingsControlProps, iconSize } from './constants.ts';
+import { iconSize } from './constants.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import { celestialBodyTypeDescription } from '../../lib/utils.ts';
 import { useModifierKey } from '../../hooks/useModifierKey.ts';
 import { ORBITAL_REGIMES } from '../../lib/regimes.ts';
+import { Settings, UpdateSettings } from '../../lib/state.ts';
 
-export function SelectOmnibox({ settings, updateSettings }: SettingsControlProps) {
+type Props = {
+  settings: Settings;
+  updateSettings: UpdateSettings;
+};
+export function SelectOmnibox({ settings, updateSettings }: Props) {
   const [query, setQuery] = useState('');
   const modifierKey = useModifierKey();
 

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -4,9 +4,13 @@ import { SettingsControlProps, buttonGap, iconSize } from './constants.ts';
 import { IconPlayerPlay, IconPlayerStop, IconPlayerTrackNext, IconPlayerTrackPrev } from '@tabler/icons-react';
 import { memo, useMemo } from 'react';
 import { dateToHumanReadable, epochToDate } from '../../lib/epoch.ts';
+import { ModelState } from '../../lib/state.ts';
 
-export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings }: SettingsControlProps) {
-  const date = new Date(Number(epochToDate(settings.epoch)) + settings.time * 1000);
+type Props = SettingsControlProps & {
+  model: ModelState;
+};
+export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings, model }: Props) {
+  const date = new Date(Number(epochToDate(settings.epoch)) + model.time * 1000);
   const [dt, dtUnits] = useMemo(() => humanTimeUnits(settings.dt), [settings.dt]);
 
   return (

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -1,12 +1,14 @@
 import { ActionIcon, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { humanTimeUnits, pluralize } from '../../lib/utils.ts';
-import { SettingsControlProps, buttonGap, iconSize } from './constants.ts';
+import { buttonGap, iconSize } from './constants.ts';
 import { IconPlayerPlay, IconPlayerStop, IconPlayerTrackNext, IconPlayerTrackPrev } from '@tabler/icons-react';
 import { memo, useMemo } from 'react';
 import { dateToHumanReadable, epochToDate } from '../../lib/epoch.ts';
-import { ModelState } from '../../lib/state.ts';
+import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
 
-type Props = SettingsControlProps & {
+type Props = {
+  settings: Settings;
+  updateSettings: UpdateSettings;
   model: ModelState;
 };
 export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings, model }: Props) {

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -1,13 +1,13 @@
 import { ActionIcon, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { humanTimeUnits, pluralize } from '../../lib/utils.ts';
-import { AppStateControlProps, buttonGap, iconSize } from './constants.ts';
+import { SettingsControlProps, buttonGap, iconSize } from './constants.ts';
 import { IconPlayerPlay, IconPlayerStop, IconPlayerTrackNext, IconPlayerTrackPrev } from '@tabler/icons-react';
 import { memo, useMemo } from 'react';
 import { dateToHumanReadable, epochToDate } from '../../lib/epoch.ts';
 
-export const TimeControls = memo(function TimeControlsComponent({ state, updateState }: AppStateControlProps) {
-  const date = new Date(Number(epochToDate(state.epoch)) + state.time * 1000);
-  const [dt, dtUnits] = useMemo(() => humanTimeUnits(state.dt), [state.dt]);
+export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings }: SettingsControlProps) {
+  const date = new Date(Number(epochToDate(settings.epoch)) + settings.time * 1000);
+  const [dt, dtUnits] = useMemo(() => humanTimeUnits(settings.dt), [settings.dt]);
 
   return (
     <Stack gap={4}>
@@ -34,17 +34,17 @@ export const TimeControls = memo(function TimeControlsComponent({ state, updateS
 
       <Group gap={buttonGap} align="flex-end">
         <Tooltip label="Slow Down">
-          <ActionIcon onClick={() => updateState({ dt: state.dt / 2 })}>
+          <ActionIcon onClick={() => updateSettings({ dt: settings.dt / 2 })}>
             <IconPlayerTrackPrev size={iconSize} />
           </ActionIcon>
         </Tooltip>
-        <Tooltip label={state.play ? 'Stop' : 'Start'}>
-          <ActionIcon onClick={() => updateState({ play: !state.play })}>
-            {state.play ? <IconPlayerStop size={iconSize} /> : <IconPlayerPlay size={iconSize} />}
+        <Tooltip label={settings.play ? 'Stop' : 'Start'}>
+          <ActionIcon onClick={() => updateSettings({ play: !settings.play })}>
+            {settings.play ? <IconPlayerStop size={iconSize} /> : <IconPlayerPlay size={iconSize} />}
           </ActionIcon>
         </Tooltip>
         <Tooltip position="right" label="Speed Up">
-          <ActionIcon onClick={() => updateState({ dt: state.dt * 2 })}>
+          <ActionIcon onClick={() => updateSettings({ dt: settings.dt * 2 })}>
             <IconPlayerTrackNext size={iconSize} />
           </ActionIcon>
         </Tooltip>

--- a/src/components/Controls/VisibilityControls.tsx
+++ b/src/components/Controls/VisibilityControls.tsx
@@ -1,10 +1,15 @@
 import { ActionIcon, Group, Menu, Tooltip } from '@mantine/core';
 import { IconCircle, IconCircleFilled, IconEyeCog } from '@tabler/icons-react';
-import { SettingsControlProps, iconSize } from './constants.ts';
+import { iconSize } from './constants.ts';
 import { CelestialBodyType, CelestialBodyTypes, HeliocentricOrbitalRegime } from '../../lib/types.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
+import { Settings, UpdateSettings } from '../../lib/state.ts';
 
-export function VisibilityControls({ settings, updateSettings }: SettingsControlProps) {
+type Props = {
+  settings: Settings;
+  updateSettings: UpdateSettings;
+};
+export function VisibilityControls({ settings, updateSettings }: Props) {
   function toggleVisibleType(type: CelestialBodyType) {
     const newVisibleTypes = settings.visibleTypes.has(type)
       ? new Set([...settings.visibleTypes].filter(t => t !== type))

--- a/src/components/Controls/VisibilityControls.tsx
+++ b/src/components/Controls/VisibilityControls.tsx
@@ -1,22 +1,22 @@
 import { ActionIcon, Group, Menu, Tooltip } from '@mantine/core';
 import { IconCircle, IconCircleFilled, IconEyeCog } from '@tabler/icons-react';
-import { AppStateControlProps, iconSize } from './constants.ts';
+import { SettingsControlProps, iconSize } from './constants.ts';
 import { CelestialBodyType, CelestialBodyTypes, HeliocentricOrbitalRegime } from '../../lib/types.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
 
-export function VisibilityControls({ state, updateState }: AppStateControlProps) {
+export function VisibilityControls({ settings, updateSettings }: SettingsControlProps) {
   function toggleVisibleType(type: CelestialBodyType) {
-    const newVisibleTypes = state.visibleTypes.has(type)
-      ? new Set([...state.visibleTypes].filter(t => t !== type))
-      : new Set([...state.visibleTypes, type]);
-    updateState({ visibleTypes: newVisibleTypes });
+    const newVisibleTypes = settings.visibleTypes.has(type)
+      ? new Set([...settings.visibleTypes].filter(t => t !== type))
+      : new Set([...settings.visibleTypes, type]);
+    updateSettings({ visibleTypes: newVisibleTypes });
   }
 
   function toggleVisibleRegime(regime: HeliocentricOrbitalRegime) {
-    const newVisibleRegimes = state.visibleRegimes.has(regime)
-      ? new Set([...state.visibleRegimes].filter(t => t !== regime))
-      : new Set([...state.visibleRegimes, regime]);
-    updateState({ visibleRegimes: newVisibleRegimes });
+    const newVisibleRegimes = settings.visibleRegimes.has(regime)
+      ? new Set([...settings.visibleRegimes].filter(t => t !== regime))
+      : new Set([...settings.visibleRegimes, regime]);
+    updateSettings({ visibleRegimes: newVisibleRegimes });
   }
 
   return (
@@ -33,7 +33,7 @@ export function VisibilityControls({ state, updateState }: AppStateControlProps)
         {CelestialBodyTypes.map(type => (
           <Menu.Item key={type} onClick={() => toggleVisibleType(type)}>
             <Group gap="xs" align="center">
-              {state.visibleTypes.has(type) ? <IconCircleFilled size={14} /> : <IconCircle size={14} />}
+              {settings.visibleTypes.has(type) ? <IconCircleFilled size={14} /> : <IconCircle size={14} />}
               {celestialBodyTypeName(type)}
             </Group>
           </Menu.Item>
@@ -43,7 +43,7 @@ export function VisibilityControls({ state, updateState }: AppStateControlProps)
         {Object.values(HeliocentricOrbitalRegime).map(regime => (
           <Menu.Item key={regime} onClick={() => toggleVisibleRegime(regime)}>
             <Group gap="xs" align="center">
-              {state.visibleRegimes.has(regime) ? <IconCircleFilled size={14} /> : <IconCircle size={14} />}
+              {settings.visibleRegimes.has(regime) ? <IconCircleFilled size={14} /> : <IconCircle size={14} />}
               {regime}
             </Group>
           </Menu.Item>

--- a/src/components/Controls/constants.ts
+++ b/src/components/Controls/constants.ts
@@ -1,9 +1,9 @@
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 
 export const iconSize = 18;
 export const buttonGap = 4;
 
-export type AppStateControlProps = {
-  state: AppState;
-  updateState: (update: Partial<AppState> | ((prev: AppState) => AppState)) => void;
+export type SettingsControlProps = {
+  settings: Settings;
+  updateSettings: (update: Partial<Settings> | ((prev: Settings) => Settings)) => void;
 };

--- a/src/components/Controls/constants.ts
+++ b/src/components/Controls/constants.ts
@@ -1,9 +1,2 @@
-import { Settings } from '../../lib/state.ts';
-
 export const iconSize = 18;
 export const buttonGap = 4;
-
-export type SettingsControlProps = {
-  settings: Settings;
-  updateSettings: (update: Partial<Settings> | ((prev: Settings) => Settings)) => void;
-};

--- a/src/components/FactSheet/AddSmallBodyButton.tsx
+++ b/src/components/FactSheet/AddSmallBodyButton.tsx
@@ -1,17 +1,16 @@
 import { Button } from '@mantine/core';
 import { IconSpherePlus } from '@tabler/icons-react';
 import { iconSize } from '../Controls/constants.ts';
-import { AppState } from '../../lib/state.ts';
 import { AddSmallBodyModal } from '../Controls/AddSmallBodyModal.tsx';
 import { CelestialBody } from '../../lib/types.ts';
 import { useDisclosure } from '@mantine/hooks';
 
 type Props = {
-  state: AppState;
+  bodies: Array<CelestialBody>;
   addBody: (body: CelestialBody) => void;
   removeBody: (name: string) => void;
 };
-export function AddSmallBodyButton({ state, addBody, removeBody }: Props) {
+export function AddSmallBodyButton({ bodies, addBody, removeBody }: Props) {
   const [isOpen, { open: onOpen, close: onClose }] = useDisclosure(false);
 
   return (
@@ -26,7 +25,7 @@ export function AddSmallBodyButton({ state, addBody, removeBody }: Props) {
       >
         Add Asteroids
       </Button>
-      <AddSmallBodyModal isOpen={isOpen} onClose={onClose} state={state} addBody={addBody} removeBody={removeBody} />
+      <AddSmallBodyModal isOpen={isOpen} onClose={onClose} bodies={bodies} addBody={addBody} removeBody={removeBody} />
     </>
   );
 }

--- a/src/components/FactSheet/CelestialBodyFactSheet.tsx
+++ b/src/components/FactSheet/CelestialBodyFactSheet.tsx
@@ -8,7 +8,7 @@ import { Thumbnail } from './Thumbnail.tsx';
 import { useFactsStream } from '../../hooks/useFactsStream.ts';
 import { LoadingCursor } from './LoadingCursor.tsx';
 import { MajorMoons } from './MajorMoons.tsx';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 import { ParentBody } from './ParentBody.tsx';
 import { OtherBodies } from './OtherBodies.tsx';
 import { Gallery } from './Gallery.tsx';
@@ -22,12 +22,12 @@ import { OtherRegimes } from './OtherRegimes.tsx';
 type Props = {
   body: CelestialBody;
   bodies: Array<CelestialBody>;
-  updateState: (update: Partial<AppState>) => void;
+  updateSettings: (update: Partial<Settings>) => void;
 };
 export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetComponent({
   body,
   bodies,
-  updateState,
+  updateSettings,
 }: Props) {
   const { name, type, mass, radius, elements, rotation } = body;
   const { data: facts, isLoading } = useFactsStream(`${name}+${type}`);
@@ -39,7 +39,7 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
   const [rotationTime, rotationUnits] = humanTimeUnits(Math.abs(rotation?.siderealPeriod ?? 0));
   const orbitalRegimePill =
     body.orbitalRegime != null ? (
-      <OrbitalRegimePill regime={body.orbitalRegime} updateState={updateState} />
+      <OrbitalRegimePill regime={body.orbitalRegime} updateSettings={updateSettings} />
     ) : undefined;
   const bullets: Array<{ label: string; value: ReactNode }> = [
     ...(orbitalRegimePill != null ? [{ label: 'orbital regime', value: orbitalRegimePill }] : []),
@@ -75,8 +75,8 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
         title={body.name}
         subTitle={celestialBodyTypeDescription(body)}
         color={body.color}
-        onClose={() => updateState({ center: null })}
-        onHover={hovered => updateState({ hover: hovered ? name : null })}
+        onClose={() => updateSettings({ center: null })}
+        onHover={hovered => updateSettings({ hover: hovered ? name : null })}
       />
 
       <FactSheetSummary obj={body} />
@@ -103,10 +103,12 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
 
       <Box style={{ justifySelf: 'flex-end' }}>
         {galleryUrls.length > 0 && <Gallery urls={galleryUrls} />}
-        <MajorMoons body={body} bodies={bodies} updateState={updateState} />
-        <ParentBody body={body} bodies={bodies} updateState={updateState} />
-        <OtherBodies body={body} bodies={bodies} updateState={updateState} />
-        {body.type === CelestialBodyType.STAR && <OtherRegimes updateState={updateState} title="Orbital Regimes" />}
+        <MajorMoons body={body} bodies={bodies} updateSettings={updateSettings} />
+        <ParentBody body={body} bodies={bodies} updateSettings={updateSettings} />
+        <OtherBodies body={body} bodies={bodies} updateSettings={updateSettings} />
+        {body.type === CelestialBodyType.STAR && (
+          <OtherRegimes updateSettings={updateSettings} title="Orbital Regimes" />
+        )}
       </Box>
     </Stack>
   );

--- a/src/components/FactSheet/FactSheet.tsx
+++ b/src/components/FactSheet/FactSheet.tsx
@@ -1,6 +1,6 @@
 import { CelestialBodyFactSheet } from './CelestialBodyFactSheet.tsx';
 import { CelestialBody, OrbitalRegime } from '../../lib/types.ts';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 import { memo } from 'react';
 import { OrbitalRegimeFactSheet } from './OrbitalRegimeFactSheet.tsx';
 
@@ -8,26 +8,26 @@ import { OrbitalRegimeFactSheet } from './OrbitalRegimeFactSheet.tsx';
 type Props = {
   body?: CelestialBody;
   regime?: OrbitalRegime;
-  state: AppState;
-  updateState: (update: Partial<AppState>) => void;
+  settings: Settings;
+  updateSettings: (update: Partial<Settings>) => void;
   addBody: (body: CelestialBody) => void;
   removeBody: (name: string) => void;
 };
 export const FactSheet = memo(function FactSheetComponent({
   body,
   regime,
-  state,
-  updateState,
+  settings,
+  updateSettings,
   addBody,
   removeBody,
 }: Props) {
   return body != null ? (
-    <CelestialBodyFactSheet body={body} bodies={state.bodies} updateState={updateState} />
+    <CelestialBodyFactSheet body={body} bodies={settings.bodies} updateSettings={updateState} />
   ) : regime != null ? (
     <OrbitalRegimeFactSheet
       regime={regime}
-      state={state}
-      updateState={updateState}
+      settings={settings}
+      updateSettings={updateSettings}
       addBody={addBody}
       removeBody={removeBody}
     />

--- a/src/components/FactSheet/FactSheet.tsx
+++ b/src/components/FactSheet/FactSheet.tsx
@@ -22,7 +22,7 @@ export const FactSheet = memo(function FactSheetComponent({
   removeBody,
 }: Props) {
   return body != null ? (
-    <CelestialBodyFactSheet body={body} bodies={settings.bodies} updateSettings={updateState} />
+    <CelestialBodyFactSheet body={body} bodies={settings.bodies} updateSettings={updateSettings} />
   ) : regime != null ? (
     <OrbitalRegimeFactSheet
       regime={regime}

--- a/src/components/FactSheet/MajorMoons.tsx
+++ b/src/components/FactSheet/MajorMoons.tsx
@@ -1,7 +1,7 @@
 import { CelestialBody, CelestialBodyType } from '../../lib/types.ts';
 import { useMemo } from 'react';
 import { Stack, Title } from '@mantine/core';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 import { BodyCard } from './BodyCard.tsx';
 
 const MAJOR_SATELLITE_TYPES = new Set([CelestialBodyType.PLANET, CelestialBodyType.MOON]);
@@ -9,9 +9,9 @@ const MAJOR_SATELLITE_TYPES = new Set([CelestialBodyType.PLANET, CelestialBodyTy
 type Props = {
   body: CelestialBody;
   bodies: Array<CelestialBody>;
-  updateState: (update: Partial<AppState>) => void;
+  updateSettings: (update: Partial<Settings>) => void;
 };
-export function MajorMoons({ body, bodies, updateState }: Props) {
+export function MajorMoons({ body, bodies, updateSettings }: Props) {
   const bodiesByName = useMemo(() => Object.fromEntries(bodies.map(b => [b.name, b])), [JSON.stringify(bodies)]);
   const moons = useMemo(
     () =>
@@ -33,8 +33,8 @@ export function MajorMoons({ body, bodies, updateState }: Props) {
         <BodyCard
           key={`${moon.name}-${i}`}
           body={moon}
-          onClick={() => updateState({ center: moon.name, hover: null })}
-          onHover={hovered => updateState({ hover: hovered ? moon.name : null })}
+          onClick={() => updateSettings({ center: moon.name, hover: null })}
+          onHover={hovered => updateSettings({ hover: hovered ? moon.name : null })}
         />
       ))}
     </Stack>

--- a/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
+++ b/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
@@ -1,5 +1,5 @@
 import { CelestialBody, HeliocentricOrbitalRegime, OrbitalRegime } from '../../lib/types.ts';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 import { Box, Stack, Title } from '@mantine/core';
 import { FactSheetTitle } from './FactSheetTitle.tsx';
 import { DEFAULT_ASTEROID_COLOR } from '../../lib/bodies.ts';
@@ -11,16 +11,16 @@ import { AddSmallBodyButton } from './AddSmallBodyButton.tsx';
 
 type Props = {
   regime: OrbitalRegime;
-  state: AppState;
-  updateState: (update: Partial<AppState>) => void;
+  settings: Settings;
+  updateSettings: (update: Partial<Settings>) => void;
   addBody: (body: CelestialBody) => void;
   removeBody: (name: string) => void;
 };
-export function OrbitalRegimeFactSheet({ regime, state, updateState, addBody, removeBody }: Props) {
+export function OrbitalRegimeFactSheet({ regime, settings, updateSettings, addBody, removeBody }: Props) {
   const isAsteroidBelt = regime.name === HeliocentricOrbitalRegime.ASTEROID_BELT;
   const bodiesInRegime = useMemo(
-    () => state.bodies.filter(body => body.orbitalRegime === regime.name),
-    [regime.name, JSON.stringify(state.bodies)]
+    () => settings.bodies.filter(body => body.orbitalRegime === regime.name),
+    [regime.name, JSON.stringify(settings.bodies)]
   );
 
   return (
@@ -29,7 +29,7 @@ export function OrbitalRegimeFactSheet({ regime, state, updateState, addBody, re
         title={regime.name}
         subTitle="Orbital Regime"
         color={DEFAULT_ASTEROID_COLOR}
-        onClose={() => updateState({ center: null })}
+        onClose={() => updateSettings({ center: null })}
       />
 
       <FactSheetSummary obj={regime} />
@@ -37,13 +37,13 @@ export function OrbitalRegimeFactSheet({ regime, state, updateState, addBody, re
       <Stack p="md" gap="xs" flex={1}>
         <Title order={5}>{isAsteroidBelt ? 'Asteroids' : 'Celestial Bodies'}</Title>
         {bodiesInRegime.map((body, i) => (
-          <BodyCard key={`${body.name}-${i}`} body={body} onClick={() => updateState({ center: body.name })} />
+          <BodyCard key={`${body.name}-${i}`} body={body} onClick={() => updateSettings({ center: body.name })} />
         ))}
-        {isAsteroidBelt && <AddSmallBodyButton state={state} addBody={addBody} removeBody={removeBody} />}
+        {isAsteroidBelt && <AddSmallBodyButton bodies={settings.bodies} addBody={addBody} removeBody={removeBody} />}
       </Stack>
 
       <Box style={{ justifySelf: 'flex-end' }}>
-        <OtherRegimes regime={regime} updateState={updateState} />
+        <OtherRegimes regime={regime} updateSettings={updateSettings} />
       </Box>
     </Stack>
   );

--- a/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
+++ b/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
@@ -3,7 +3,7 @@ import { Settings } from '../../lib/state.ts';
 import { Box, Stack, Title } from '@mantine/core';
 import { FactSheetTitle } from './FactSheetTitle.tsx';
 import { DEFAULT_ASTEROID_COLOR } from '../../lib/bodies.ts';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { BodyCard } from './BodyCard.tsx';
 import { FactSheetSummary } from './FactSheetSummary.tsx';
 import { OtherRegimes } from './OtherRegimes.tsx';
@@ -16,7 +16,13 @@ type Props = {
   addBody: (body: CelestialBody) => void;
   removeBody: (name: string) => void;
 };
-export function OrbitalRegimeFactSheet({ regime, settings, updateSettings, addBody, removeBody }: Props) {
+export const OrbitalRegimeFactSheet = memo(function OrbitalRegimeFactSheetComponent({
+  regime,
+  settings,
+  updateSettings,
+  addBody,
+  removeBody,
+}: Props) {
   const isAsteroidBelt = regime.name === HeliocentricOrbitalRegime.ASTEROID_BELT;
   const bodiesInRegime = useMemo(
     () => settings.bodies.filter(body => body.orbitalRegime === regime.name),
@@ -47,4 +53,4 @@ export function OrbitalRegimeFactSheet({ regime, settings, updateSettings, addBo
       </Box>
     </Stack>
   );
-}
+});

--- a/src/components/FactSheet/OrbitalRegimePill.tsx
+++ b/src/components/FactSheet/OrbitalRegimePill.tsx
@@ -1,21 +1,21 @@
 import { Group, Pill } from '@mantine/core';
 import { HeliocentricOrbitalRegime } from '../../lib/types.ts';
 import styles from './RelatedBodies.module.css';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 import { IconCircleDotFilled } from '@tabler/icons-react';
 
 type Props = {
   regime: HeliocentricOrbitalRegime;
-  updateState: (update: Partial<AppState>) => void;
+  updateSettings: (update: Partial<Settings>) => void;
 };
-export function OrbitalRegimePill({ regime, updateState }: Props) {
+export function OrbitalRegimePill({ regime, updateSettings }: Props) {
   return (
     <Pill
       className={styles.LinkPill}
       style={{ cursor: 'pointer' }}
-      onClick={() => updateState({ center: regime, hover: null })}
-      onMouseEnter={() => updateState({ hover: regime })}
-      onMouseLeave={() => updateState({ hover: null })}
+      onClick={() => updateSettings({ center: regime, hover: null })}
+      onMouseEnter={() => updateSettings({ hover: regime })}
+      onMouseLeave={() => updateSettings({ hover: null })}
     >
       <Group gap={8} align="center" wrap="nowrap">
         <IconCircleDotFilled size={14} />

--- a/src/components/FactSheet/OtherBodies.tsx
+++ b/src/components/FactSheet/OtherBodies.tsx
@@ -1,5 +1,5 @@
 import { CelestialBody } from '../../lib/types.ts';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
 import { Box, Group, Pill, Stack, Title } from '@mantine/core';
 import styles from './RelatedBodies.module.css';
@@ -11,9 +11,9 @@ const N_RELATED = 6;
 type Props = {
   body: CelestialBody;
   bodies: Array<CelestialBody>;
-  updateState: (update: Partial<AppState>) => void;
+  updateSettings: (update: Partial<Settings>) => void;
 };
-export function OtherBodies({ body, bodies, updateState }: Props) {
+export function OtherBodies({ body, bodies, updateSettings }: Props) {
   const otherBodies: Array<CelestialBody> = useMemo(() => {
     const bodiesOfType = bodies.filter(({ type }) => type === body.type);
     const bodyIndex = bodiesOfType.findIndex(({ name }) => name === body.name);
@@ -33,9 +33,9 @@ export function OtherBodies({ body, bodies, updateState }: Props) {
             key={`${relatedBody.name}-${i}`}
             className={styles.LinkPill}
             style={{ cursor: 'pointer' }}
-            onClick={() => updateState({ center: relatedBody.name, hover: null })}
-            onMouseEnter={() => updateState({ hover: relatedBody.name })}
-            onMouseLeave={() => updateState({ hover: null })}
+            onClick={() => updateSettings({ center: relatedBody.name, hover: null })}
+            onMouseEnter={() => updateSettings({ hover: relatedBody.name })}
+            onMouseLeave={() => updateSettings({ hover: null })}
           >
             <Group gap={8} align="center" wrap="nowrap">
               <Box w={thumbnailSize}>

--- a/src/components/FactSheet/OtherRegimes.tsx
+++ b/src/components/FactSheet/OtherRegimes.tsx
@@ -3,14 +3,14 @@ import { OrbitalRegimePill } from './OrbitalRegimePill.tsx';
 import { OrbitalRegime } from '../../lib/types.ts';
 import { useMemo } from 'react';
 import { ORBITAL_REGIMES } from '../../lib/regimes.ts';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 
 type Props = {
   regime?: OrbitalRegime;
-  updateState: (update: Partial<AppState>) => void;
+  updateSettings: (update: Partial<Settings>) => void;
   title?: string;
 };
-export function OtherRegimes({ regime, updateState, title = 'Other Orbital Regimes' }: Props) {
+export function OtherRegimes({ regime, updateSettings, title = 'Other Orbital Regimes' }: Props) {
   const otherRegimes: Array<OrbitalRegime> = useMemo(
     () => ORBITAL_REGIMES.filter(({ name }) => name !== regime?.name),
     [JSON.stringify(regime)]
@@ -21,7 +21,11 @@ export function OtherRegimes({ regime, updateState, title = 'Other Orbital Regim
       <Title order={5}>{title}</Title>
       <Group gap={8}>
         {otherRegimes.map((otherRegime, i) => (
-          <OrbitalRegimePill key={`${otherRegime.name}-${i}`} regime={otherRegime.name} updateState={updateState} />
+          <OrbitalRegimePill
+            key={`${otherRegime.name}-${i}`}
+            regime={otherRegime.name}
+            updateSettings={updateSettings}
+          />
         ))}
       </Group>
     </Stack>

--- a/src/components/FactSheet/ParentBody.tsx
+++ b/src/components/FactSheet/ParentBody.tsx
@@ -1,5 +1,5 @@
 import { CelestialBody, CelestialBodyType } from '../../lib/types.ts';
-import { AppState } from '../../lib/state.ts';
+import { Settings } from '../../lib/state.ts';
 import { Stack, Title } from '@mantine/core';
 import { BodyCard } from './BodyCard.tsx';
 import { useMemo } from 'react';
@@ -8,9 +8,9 @@ import { celestialBodyTypeName } from '../../lib/utils.ts';
 type Props = {
   body: CelestialBody;
   bodies: Array<CelestialBody>;
-  updateState: (update: Partial<AppState>) => void;
+  updateSettings: (update: Partial<Settings>) => void;
 };
-export function ParentBody({ body, bodies, updateState }: Props) {
+export function ParentBody({ body, bodies, updateSettings }: Props) {
   const parentBody = useMemo(
     () => bodies.find(({ type, name }) => type !== CelestialBodyType.STAR && name === body.elements.wrt),
     [JSON.stringify(body), JSON.stringify(bodies)]
@@ -20,8 +20,8 @@ export function ParentBody({ body, bodies, updateState }: Props) {
       <Title order={5}>Parent {celestialBodyTypeName(parentBody.type)}</Title>
       <BodyCard
         body={parentBody}
-        onClick={() => updateState({ center: parentBody.name, hover: null })}
-        onHover={hovered => updateState({ hover: hovered ? parentBody.name : null })}
+        onClick={() => updateSettings({ center: parentBody.name, hover: null })}
+        onHover={hovered => updateSettings({ hover: hovered ? parentBody.name : null })}
       />
     </Stack>
   ) : (

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Group, Stack } from '@mantine/core';
-import { clampSettings, Settings, initialState } from '../lib/state.ts';
+import { clampSettings, initialState, UpdateSettings } from '../lib/state.ts';
 import { Controls } from './Controls/Controls.tsx';
 import { useSolarSystemModel } from '../hooks/useSolarSystemModel.ts';
 import { useCursorControls } from '../hooks/useCursorControls.ts';
@@ -17,8 +17,8 @@ export function SolarSystem() {
   const isSmallDisplay = useIsSmallDisplay();
   const { settings } = appState;
 
-  const updateSettings = useCallback(
-    (update: Partial<Settings> | ((prev: Settings) => Settings)) => {
+  const updateSettings: UpdateSettings = useCallback(
+    update => {
       setAppState(prev => {
         const updated = typeof update === 'function' ? update(prev.settings) : { ...prev.settings, ...update };
         const newState = { ...prev, settings: clampSettings(updated) };

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Group, Stack } from '@mantine/core';
-import { AppState, clampState, initialState } from '../lib/state.ts';
+import { clampSettings, Settings, initialState } from '../lib/state.ts';
 import { Controls } from './Controls/Controls.tsx';
 import { useSolarSystemModel } from '../hooks/useSolarSystemModel.ts';
 import { useCursorControls } from '../hooks/useCursorControls.ts';
@@ -15,44 +15,49 @@ export function SolarSystem() {
   const appStateRef = useRef(appState);
   const model = useSolarSystemModel();
   const isSmallDisplay = useIsSmallDisplay();
+  const { settings } = appState;
 
-  const updateState = useCallback(
-    (update: Partial<AppState> | ((prev: AppState) => AppState)) => {
+  const updateSettings = useCallback(
+    (update: Partial<Settings> | ((prev: Settings) => Settings)) => {
       setAppState(prev => {
-        const updated = typeof update === 'function' ? update(prev) : { ...prev, ...update };
-        const updatedClamped = clampState(updated);
+        const updated = typeof update === 'function' ? update(prev.settings) : { ...prev.settings, ...update };
+        const newState = { ...prev, settings: clampSettings(updated) };
         // set the mutable state ref (accessed by animation callback) on state update
-        appStateRef.current = updatedClamped;
-        return updatedClamped;
+        appStateRef.current = newState;
+        return newState;
       });
     },
     [setAppState]
   );
 
-  const cursorControls = useCursorControls(model.modelRef.current, appState, updateState);
+  const cursorControls = useCursorControls(model.modelRef.current, settings, updateSettings);
 
   function addBody(body: CelestialBody) {
-    updateState(prev => ({ ...prev, bodies: [...prev.bodies, body] }));
+    updateSettings(prev => ({ ...prev, bodies: [...prev.bodies, body] }));
     model.add(appStateRef.current, body);
   }
 
   function removeBody(name: string) {
-    updateState(prev => ({ ...prev, bodies: prev.bodies.filter(b => b.name !== name) }));
+    updateSettings(prev => ({ ...prev, bodies: prev.bodies.filter(b => b.name !== name) }));
     model.remove(name);
   }
 
   const resetState = useCallback(() => {
-    updateState(initialState);
+    updateSettings(initialState.settings);
     model.reset(initialState);
-  }, [updateState]);
+  }, [updateSettings]);
 
   // TODO: pretty sure there's an issue with dev reloads spawning multiple animation loops
   function animationFrame() {
-    const { play, time, dt, metersPerPx, vernalEquinox } = appStateRef.current;
-    updateState({
-      time: play ? time + dt : time,
-      metersPerPx: model.modelRef.current?.getMetersPerPixel() ?? metersPerPx,
-      vernalEquinox: model.modelRef?.current?.getVernalEquinox() ?? vernalEquinox,
+    setAppState(prev => {
+      const newModel = {
+        time: prev.settings.play ? prev.model.time + prev.settings.dt : prev.model.time,
+        metersPerPx: model.modelRef.current?.getMetersPerPixel() ?? prev.model.metersPerPx,
+        vernalEquinox: model.modelRef?.current?.getVernalEquinox() ?? prev.model.vernalEquinox,
+      };
+      const newState = { ...prev, model: newModel };
+      appStateRef.current = newState;
+      return newState;
     });
     const ctx = model.canvasRef.current?.getContext('2d');
     if (ctx != null) {
@@ -71,20 +76,20 @@ export function SolarSystem() {
 
   useEffect(() => {
     model.resize();
-  }, [appState.center]);
+  }, [settings.center]);
 
   const focusBody = useMemo(
-    () => appState.bodies.find(body => body.name === appState.center),
-    [appState.center, JSON.stringify(appState.bodies)]
+    () => settings.bodies.find(body => body.name === settings.center),
+    [settings.center, JSON.stringify(settings.bodies)]
   );
-  const focusRegime = useMemo(() => ORBITAL_REGIMES.find(({ name }) => name === appState.center), [appState.center]);
+  const focusRegime = useMemo(() => ORBITAL_REGIMES.find(({ name }) => name === settings.center), [settings.center]);
 
   const LayoutComponent = isSmallDisplay ? Stack : Group;
   return (
     <LayoutComponent gap={0} w="100vw" h="100dvh" flex={1}>
       <Box pos="relative" w="100%" h="100dvh" flex={1}>
         <Box
-          style={{ cursor: appState.hover != null ? 'pointer' : 'unset' }}
+          style={{ cursor: settings.hover != null ? 'pointer' : 'unset' }}
           ref={model.containerRef}
           pos="absolute"
           w="100%"
@@ -95,7 +100,7 @@ export function SolarSystem() {
           ref={model.canvasRef}
           style={{ height: '100%', width: '100%', position: 'absolute', pointerEvents: 'none' }}
         />
-        <Controls state={appState} updateState={updateState} reset={resetState} />
+        <Controls settings={settings} updateSettings={updateSettings} model={appState.model} reset={resetState} />
       </Box>
       {(focusBody != null || focusRegime != null) && (
         <Box
@@ -110,8 +115,8 @@ export function SolarSystem() {
             key={focusBody?.name ?? focusRegime?.name} // ensure that the component is rerendered when focus changes
             body={focusBody}
             regime={focusRegime}
-            state={appState}
-            updateState={updateState}
+            settings={settings}
+            updateSettings={updateSettings}
             addBody={addBody}
             removeBody={removeBody}
           />

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -33,8 +33,10 @@ export function SolarSystem() {
   const cursorControls = useCursorControls(model.modelRef.current, settings, updateSettings);
 
   function addBody(body: CelestialBody) {
-    updateSettings(prev => ({ ...prev, bodies: [...prev.bodies, body] }));
-    model.add(appStateRef.current, body);
+    updateSettings(prev => {
+      model.add(prev, body);
+      return { ...prev, bodies: [...prev.bodies, body] };
+    });
   }
 
   function removeBody(name: string) {
@@ -43,8 +45,9 @@ export function SolarSystem() {
   }
 
   const resetState = useCallback(() => {
-    updateSettings(initialState.settings);
-    model.reset(initialState);
+    setAppState(initialState);
+    appStateRef.current = initialState;
+    model.reset(initialState.settings);
   }, [updateSettings]);
 
   // TODO: pretty sure there's an issue with dev reloads spawning multiple animation loops
@@ -61,14 +64,14 @@ export function SolarSystem() {
     });
     const ctx = model.canvasRef.current?.getContext('2d');
     if (ctx != null) {
-      model.update(ctx, appStateRef.current);
+      model.update(ctx, appStateRef.current.settings);
     }
     window.requestAnimationFrame(animationFrame);
   }
 
   useEffect(() => {
     const frameId = window.requestAnimationFrame(animationFrame);
-    model.initialize(appStateRef.current);
+    model.initialize(appStateRef.current.settings);
     return () => {
       window.cancelAnimationFrame(frameId);
     };

--- a/src/hooks/useCursorControls.ts
+++ b/src/hooks/useCursorControls.ts
@@ -1,7 +1,7 @@
 import { MouseEvent, PointerEvent, useRef } from 'react';
 import { SolarSystemModel } from '../lib/model/SolarSystemModel.ts';
 import { Point2 } from '../lib/types.ts';
-import { AppState } from '../lib/state.ts';
+import { Settings } from '../lib/state.ts';
 import { magnitude, subtract3 } from '../lib/physics.ts';
 import { useIsTouchDevice } from './useIsTouchDevice.ts';
 
@@ -14,8 +14,8 @@ type DragDetector = {
 
 export function useCursorControls(
   model: SolarSystemModel | null,
-  { visibleTypes }: AppState,
-  updateAppState: (state: Partial<AppState>) => void
+  { visibleTypes }: Settings,
+  updateSettings: (state: Partial<Settings>) => void
 ) {
   const isTouchDevice = useIsTouchDevice();
   const dragDetectorRef = useRef<DragDetector | null>(null);
@@ -44,7 +44,7 @@ export function useCursorControls(
 
     if (model == null) return;
     const closeBody = model.findCloseBody(eventPx, visibleTypes, interactPxThreshold);
-    updateAppState({ hover: closeBody?.body?.name ?? null });
+    updateSettings({ hover: closeBody?.body?.name ?? null });
   }
 
   function onClick(event: MouseEvent<HTMLElement>) {
@@ -59,7 +59,7 @@ export function useCursorControls(
 
     const closeBody = model.findCloseBody(getCursorCoordinates(event), visibleTypes, interactPxThreshold);
     if (closeBody != null) {
-      updateAppState({ center: closeBody.body.name });
+      updateSettings({ center: closeBody.body.name });
     }
   }
 

--- a/src/hooks/useSolarSystemModel.ts
+++ b/src/hooks/useSolarSystemModel.ts
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { SolarSystemModel } from '../lib/model/SolarSystemModel.ts';
 import { CelestialBody } from '../lib/types.ts';
-import { AppState } from '../lib/state.ts';
+import { Settings } from '../lib/state.ts';
 
 export function useSolarSystemModel() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -20,10 +20,10 @@ export function useSolarSystemModel() {
     ctx.translate(0, -canvas.height / dpr);
   }
 
-  function initialize(appState: AppState) {
+  function initialize(settings: Settings) {
     if (containerRef.current == null || canvasRef.current == null) return;
     if (modelRef.current == null) {
-      modelRef.current = new SolarSystemModel(containerRef.current, appState);
+      modelRef.current = new SolarSystemModel(containerRef.current, settings);
     }
     initializeCanvas();
     window.addEventListener('resize', resize);
@@ -42,20 +42,20 @@ export function useSolarSystemModel() {
     initializeCanvas();
   }
 
-  function update(ctx: CanvasRenderingContext2D, appState: AppState) {
-    modelRef.current?.update(ctx, appState);
+  function update(ctx: CanvasRenderingContext2D, settings: Settings) {
+    modelRef.current?.update(ctx, settings);
   }
 
-  function add(appState: AppState, body: CelestialBody) {
-    modelRef.current?.add(appState, body);
+  function add(settings: Settings, body: CelestialBody) {
+    modelRef.current?.add(settings, body);
   }
 
   function remove(name: string) {
     modelRef.current?.remove(name);
   }
 
-  function reset(appState: AppState) {
-    modelRef.current?.reset(appState);
+  function reset(settings: Settings) {
+    modelRef.current?.reset(settings);
   }
 
   return {

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -1,7 +1,7 @@
 import { CelestialBody, CelestialBodyType, Point2 } from '../types.ts';
 import { HOVER_SCALE_FACTOR, SCALE_FACTOR } from './constants.ts';
 import { Color, OrthographicCamera, Scene, Vector2, Vector3 } from 'three';
-import { AppState } from '../state.ts';
+import { Settings } from '../state.ts';
 import { drawDotAtLocation, drawLabelAtLocation, drawOffscreenIndicator, getCanvasPixels } from './canvas.ts';
 import { isOffScreen } from './utils.ts';
 import { KinematicBody } from './KinematicBody.ts';
@@ -27,7 +27,7 @@ export class KeplerianBody extends KinematicBody {
   constructor(
     scene: Scene,
     resolution: Vector2,
-    appState: AppState,
+    settings: Settings,
     parent: KeplerianBody | null,
     body: CelestialBody,
     position: Vector3,
@@ -37,7 +37,7 @@ export class KeplerianBody extends KinematicBody {
     this.body = body;
     this.resolution = resolution;
     this.screenPosition = new Vector3();
-    this.visible = appState.visibleTypes.has(body.type);
+    this.visible = settings.visibleTypes.has(body.type);
     const color = new Color(body.color);
     this.ellipse = new OrbitalEllipse(scene, resolution, body.elements, parent?.position ?? null, position, color);
     this.radius = new FocalRadius(scene, resolution, parent?.position ?? new Vector3(), position, color);
@@ -48,13 +48,13 @@ export class KeplerianBody extends KinematicBody {
     }
   }
 
-  update(appState: AppState, parent: this | null) {
-    this.visible = appState.visibleTypes.has(this.body.type);
+  update(settings: Settings, parent: this | null) {
+    this.visible = settings.visibleTypes.has(this.body.type);
     this.sphere.update(this.position, this.rotation, this.visible);
-    this.ellipse.update(parent?.position ?? null, this.visible && appState.drawOrbit);
+    this.ellipse.update(parent?.position ?? null, this.visible && settings.drawOrbit);
 
     // apply hover effects (scale body, bold ellipse, etc.)
-    const thisIsHovered = appState.hover === this.body.name;
+    const thisIsHovered = settings.hover === this.body.name;
     if (thisIsHovered !== this.hovered) {
       this.sphere.setHover(thisIsHovered);
       this.ellipse.setHover(thisIsHovered);

--- a/src/lib/model/OrbitalRegime.ts
+++ b/src/lib/model/OrbitalRegime.ts
@@ -9,7 +9,7 @@ import {
   OneFactor,
   DoubleSide,
 } from 'three';
-import { AppState } from '../state.ts';
+import { Settings } from '../state.ts';
 import { OrbitalRegime as OrbitalRegimeType } from '../types.ts';
 import { SCALE_FACTOR } from './constants.ts';
 
@@ -18,7 +18,7 @@ export class OrbitalRegime {
   readonly scene: Scene;
   readonly mesh: Mesh;
 
-  constructor(scene: Scene, appState: AppState, regime: OrbitalRegimeType) {
+  constructor(scene: Scene, settings: Settings, regime: OrbitalRegimeType) {
     this.regime = regime;
     this.scene = scene;
 
@@ -37,13 +37,13 @@ export class OrbitalRegime {
       blendDst: OneFactor,
     });
     this.mesh = new Mesh(geometry, material);
-    this.mesh.visible = this.isVisible(appState);
+    this.mesh.visible = this.isVisible(settings);
     this.mesh.scale.z = regime.roundness; // flatten or stretch torus
     scene.add(this.mesh);
   }
 
-  update(appState: AppState) {
-    this.mesh.visible = this.isVisible(appState);
+  update(settings: Settings) {
+    this.mesh.visible = this.isVisible(settings);
   }
 
   dispose() {
@@ -52,11 +52,11 @@ export class OrbitalRegime {
     this.scene.remove(this.mesh);
   }
 
-  private isVisible(appState: AppState) {
+  private isVisible(settings: Settings) {
     return (
-      appState.hover === this.regime.name ||
-      appState.center === this.regime.name ||
-      appState.visibleRegimes.has(this.regime.name)
+      settings.hover === this.regime.name ||
+      settings.center === this.regime.name ||
+      settings.visibleRegimes.has(this.regime.name)
     );
   }
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -16,10 +16,9 @@ export type Settings = {
   bodies: Array<CelestialBody>;
 };
 
+// these values are readonly; driven by the model
 export type ModelState = {
   time: number; // seconds
-  // TODO: should these really live here?
-  // these values are readonly; driven by the model
   metersPerPx: number; // describes zoom
   vernalEquinox: Point3; // direction of the Vernal Equinox
 };
@@ -66,3 +65,5 @@ export function clampSettings({ dt, ...settings }: Settings): Settings {
     dt: Math.min(Math.max(dt, Time.SECOND), 365 * Time.DAY),
   };
 }
+
+export type UpdateSettings = (update: Partial<Settings> | ((prev: Settings) => Settings)) => void;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -2,9 +2,8 @@ import { SOLAR_SYSTEM, Time } from './bodies.ts';
 import { CelestialBody, CelestialBodyType, Epoch, HeliocentricOrbitalRegime, Point3 } from './types.ts';
 import { nowEpoch } from './epoch.ts';
 
-export type AppState = {
+export type Settings = {
   epoch: Epoch;
-  time: number; // seconds
   dt: number; // seconds
   play: boolean;
   drawTail: boolean;
@@ -15,43 +14,55 @@ export type AppState = {
   visibleTypes: Set<CelestialBodyType>;
   visibleRegimes: Set<HeliocentricOrbitalRegime>;
   bodies: Array<CelestialBody>;
+};
 
+export type ModelState = {
+  time: number; // seconds
   // TODO: should these really live here?
   // these values are readonly; driven by the model
   metersPerPx: number; // describes zoom
   vernalEquinox: Point3; // direction of the Vernal Equinox
 };
 
-export const initialState: AppState = {
-  epoch: nowEpoch(),
-  time: 0,
-  dt: 30 * Time.MINUTE,
-  play: true,
-  drawTail: false,
-  drawOrbit: true,
-  drawLabel: true,
-  center: null,
-  hover: null,
-  visibleTypes: new Set([
-    CelestialBodyType.STAR,
-    CelestialBodyType.PLANET,
-    CelestialBodyType.MOON,
-    CelestialBodyType.DWARF_PLANET,
-    CelestialBodyType.ASTEROID,
-    CelestialBodyType.TRANS_NEPTUNIAN_OBJECT,
-    // absent: comet, spacecraft
-  ]),
-  visibleRegimes: new Set([]),
-  bodies: SOLAR_SYSTEM,
-
-  // set by model on update
-  metersPerPx: 1,
-  vernalEquinox: [1, 0, 0],
+export type AppState = {
+  settings: Settings;
+  model: ModelState;
 };
 
-export function clampState({ dt, ...state }: AppState): AppState {
+export const initialState: AppState = {
+  settings: {
+    epoch: nowEpoch(),
+    dt: 30 * Time.MINUTE,
+    play: true,
+    drawTail: false,
+    drawOrbit: true,
+    drawLabel: true,
+    center: null,
+    hover: null,
+    visibleTypes: new Set([
+      CelestialBodyType.STAR,
+      CelestialBodyType.PLANET,
+      CelestialBodyType.MOON,
+      CelestialBodyType.DWARF_PLANET,
+      CelestialBodyType.ASTEROID,
+      CelestialBodyType.TRANS_NEPTUNIAN_OBJECT,
+      // absent: comet, spacecraft
+    ]),
+    visibleRegimes: new Set([]),
+    bodies: SOLAR_SYSTEM,
+  },
+
+  // set by model on update
+  model: {
+    time: 0,
+    metersPerPx: 1,
+    vernalEquinox: [1, 0, 0],
+  },
+};
+
+export function clampSettings({ dt, ...settings }: Settings): Settings {
   return {
-    ...state,
+    ...settings,
     dt: Math.min(Math.max(dt, Time.SECOND), 365 * Time.DAY),
   };
 }


### PR DESCRIPTION
Settings are controlled by the UI and drive the model. Model state is driven by the simulation and displayed (but not edited) on the UI. Separating these two is much cleaner and allows for better memoization as most components don't need the model state (changes every frame), just the settings state (changes when buttons are clicked).

Note that the "model state" is different from the model (simulation) itself; it's a readonly convenience extracting relevant information from the model to feed into frontend components (time, meters per pixel, direction of the vernal equinox). 