### PR TITLE
Support reverse time + connect playback speed to real time units

### DIFF
--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -45,7 +45,7 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
       <Paper radius="md">
         <Stack gap={2} fz="xs">
           <Group gap={8}>
-            <Group justify="flex-end" w={36}>
+            <Group justify="flex-end" w={40}>
               <Text inherit c="dimmed">
                 date
               </Text>
@@ -53,7 +53,7 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
             <Text inherit>{dateToHumanReadable(date)}</Text>
           </Group>
           <Group gap={8}>
-            <Group justify="flex-end" w={36}>
+            <Group justify="flex-end" w={40}>
               <Text inherit c="dimmed">
                 speed
               </Text>

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { IconPlayerPlay, IconPlayerStop, IconPlayerTrackNext, IconPlayerTrackPrev } from '@tabler/icons-react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { dateToHumanReadable, epochToDate, Time } from '../../lib/epoch.ts';
 import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
 import { humanTimeUnits, pluralize } from '../../lib/utils.ts';
@@ -36,7 +36,7 @@ type Props = {
 };
 export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings, model }: Props) {
   const date = new Date(Number(epochToDate(settings.epoch)) + model.time * 1000);
-  const [t, tUnits] = humanTimeUnits(settings.speed, true);
+  const [t, tUnits] = useMemo(() => humanTimeUnits(settings.speed, true), [settings.speed]);
 
   const slowDownDisabled = settings.speed < 0 && settings.speed <= -FASTEST_SPEED;
   const speedUpDisabled = settings.speed > 0 && settings.speed >= FASTEST_SPEED;

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -35,6 +35,14 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
             </Group>
             <Text inherit>{pluralize(dt, dtUnits)}</Text>
           </Group>
+          <Group gap={8}>
+            <Group justify="flex-end" w={20}>
+              <Text inherit c="dimmed">
+                fps
+              </Text>
+            </Group>
+            <Text inherit>{model.fps.toFixed(0)}</Text>
+          </Group>
         </Stack>
       </Paper>
 

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -18,28 +18,28 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
       <Paper radius="md">
         <Stack gap={2} fz="xs">
           <Group gap={8}>
-            <Group justify="flex-end" w={20}>
+            <Group justify="flex-end" w={36}>
               <Text inherit c="dimmed">
-                t
+                date
               </Text>
             </Group>
             <Text inherit>{dateToHumanReadable(date)}</Text>
           </Group>
           <Group gap={8}>
-            <Group justify="flex-end" w={20}>
+            <Group justify="flex-end" w={36}>
               <Text inherit c="dimmed">
-                ∆t
+                speed
               </Text>
             </Group>
-            <Text inherit>x{settings.playbackSpeed}</Text>
+            <Text inherit>{settings.playbackSpeed.toLocaleString()}x</Text>
           </Group>
           <Group gap={8}>
-            <Group justify="flex-end" w={20}>
+            <Group justify="flex-end" w={36}>
               <Text inherit c="dimmed">
                 fps
               </Text>
             </Group>
-            <Text inherit>{model.fps.toFixed(0)}</Text>
+            <Text inherit>{model.fps?.toFixed(0)}</Text>
           </Group>
         </Stack>
       </Paper>
@@ -49,7 +49,7 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
           <ActionIcon
             onClick={() =>
               updateSettings(({ playbackSpeed, ...prev }) => {
-                const next = playbackSpeed > 0 ? (playbackSpeed <= 1 ? -1 : playbackSpeed / 2) : playbackSpeed * 2;
+                const next = playbackSpeed > 0 ? (playbackSpeed <= 1 ? -1 : playbackSpeed / 10) : playbackSpeed * 10;
                 return { ...prev, playbackSpeed: next };
               })
             }
@@ -66,7 +66,7 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
           <ActionIcon
             onClick={() => {
               updateSettings(({ playbackSpeed, ...prev }) => {
-                const next = playbackSpeed < 0 ? (playbackSpeed >= -1 ? 1 : playbackSpeed / 2) : playbackSpeed * 2;
+                const next = playbackSpeed < 0 ? (playbackSpeed >= -1 ? 1 : playbackSpeed / 10) : playbackSpeed * 10;
                 return { ...prev, playbackSpeed: next };
               });
             }}

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -1,9 +1,8 @@
 import { ActionIcon, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { IconPlayerPlay, IconPlayerStop, IconPlayerTrackNext, IconPlayerTrackPrev } from '@tabler/icons-react';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { dateToHumanReadable, epochToDate } from '../../lib/epoch.ts';
 import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
-import { humanTimeUnits, pluralize } from '../../lib/utils.ts';
 import { buttonGap, iconSize } from './constants.ts';
 
 type Props = {
@@ -13,7 +12,6 @@ type Props = {
 };
 export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings, model }: Props) {
   const date = new Date(Number(epochToDate(settings.epoch)) + model.time * 1000);
-  const [dt, dtUnits] = useMemo(() => humanTimeUnits(settings.dt), [settings.dt]);
 
   return (
     <Stack gap={4}>
@@ -33,7 +31,7 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
                 ∆t
               </Text>
             </Group>
-            <Text inherit>{pluralize(dt, dtUnits)}</Text>
+            <Text inherit>x{settings.playbackSpeed}</Text>
           </Group>
           <Group gap={8}>
             <Group justify="flex-end" w={20}>
@@ -48,7 +46,14 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
 
       <Group gap={buttonGap} align="flex-end">
         <Tooltip label="Slow Down">
-          <ActionIcon onClick={() => updateSettings({ dt: settings.dt / 2 })}>
+          <ActionIcon
+            onClick={() =>
+              updateSettings(({ playbackSpeed, ...prev }) => {
+                const next = playbackSpeed > 0 ? (playbackSpeed <= 1 ? -1 : playbackSpeed / 2) : playbackSpeed * 2;
+                return { ...prev, playbackSpeed: next };
+              })
+            }
+          >
             <IconPlayerTrackPrev size={iconSize} />
           </ActionIcon>
         </Tooltip>
@@ -58,7 +63,14 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
           </ActionIcon>
         </Tooltip>
         <Tooltip position="right" label="Speed Up">
-          <ActionIcon onClick={() => updateSettings({ dt: settings.dt * 2 })}>
+          <ActionIcon
+            onClick={() => {
+              updateSettings(({ playbackSpeed, ...prev }) => {
+                const next = playbackSpeed < 0 ? (playbackSpeed >= -1 ? 1 : playbackSpeed / 2) : playbackSpeed * 2;
+                return { ...prev, playbackSpeed: next };
+              });
+            }}
+          >
             <IconPlayerTrackNext size={iconSize} />
           </ActionIcon>
         </Tooltip>

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -5,7 +5,7 @@ import { useIsSmallDisplay } from '../hooks/useIsSmallDisplay.ts';
 import { useSolarSystemModel } from '../hooks/useSolarSystemModel.ts';
 import { DEFAULT_ASTEROID_COLOR } from '../lib/bodies.ts';
 import { ORBITAL_REGIMES } from '../lib/regimes.ts';
-import { clampSettings, initialState, UpdateSettings } from '../lib/state.ts';
+import { initialState, UpdateSettings } from '../lib/state.ts';
 import { CelestialBody, isCelestialBody } from '../lib/types.ts';
 import { Controls } from './Controls/Controls.tsx';
 import { FactSheet } from './FactSheet/FactSheet.tsx';
@@ -21,7 +21,7 @@ export function SolarSystem() {
     update => {
       setAppState(prev => {
         const updated = typeof update === 'function' ? update(prev.settings) : { ...prev.settings, ...update };
-        const newState = { ...prev, settings: clampSettings(updated) };
+        const newState = { ...prev, settings: updated };
         // set the mutable state ref (accessed by animation callback) on state update
         appStateRef.current = newState;
         return newState;

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -5,7 +5,7 @@ import { useIsSmallDisplay } from '../hooks/useIsSmallDisplay.ts';
 import { useSolarSystemModel } from '../hooks/useSolarSystemModel.ts';
 import { DEFAULT_ASTEROID_COLOR } from '../lib/bodies.ts';
 import { ORBITAL_REGIMES } from '../lib/regimes.ts';
-import { initialState, UpdateSettings } from '../lib/state.ts';
+import { clampSettings, initialState, UpdateSettings } from '../lib/state.ts';
 import { CelestialBody, isCelestialBody } from '../lib/types.ts';
 import { Controls } from './Controls/Controls.tsx';
 import { FactSheet } from './FactSheet/FactSheet.tsx';
@@ -21,7 +21,7 @@ export function SolarSystem() {
     update => {
       setAppState(prev => {
         const updated = typeof update === 'function' ? update(prev.settings) : { ...prev.settings, ...update };
-        const newState = { ...prev, settings: updated };
+        const newState = { ...prev, settings: clampSettings(updated) };
         // set the mutable state ref (accessed by animation callback) on state update
         appStateRef.current = newState;
         return newState;

--- a/src/lib/epoch.ts
+++ b/src/lib/epoch.ts
@@ -5,6 +5,9 @@ export enum Time {
   MINUTE = 60 * SECOND,
   HOUR = 60 * MINUTE,
   DAY = 24 * HOUR,
+  WEEK = 7 * DAY,
+  MONTH = 30.436875 * DAY,
+  YEAR = 365.25 * DAY,
 }
 
 export const J2000: Epoch = {

--- a/src/lib/model/FrameRateCounter.ts
+++ b/src/lib/model/FrameRateCounter.ts
@@ -1,0 +1,25 @@
+export class FrameRateCounter {
+  private readonly array: Array<number>;
+  private readonly size = 60;
+
+  private oldestIndex = 0;
+  private newestIndex = 0;
+
+  constructor() {
+    this.array = new Array(this.size).fill(performance.now());
+  }
+
+  update() {
+    this.newestIndex = (this.newestIndex + 1) % this.size;
+    this.array[this.newestIndex] = performance.now();
+    if (this.newestIndex === this.oldestIndex) {
+      this.oldestIndex = (this.oldestIndex + 1) % this.size;
+    }
+  }
+
+  fps() {
+    const elapsed = this.array[this.newestIndex] - this.array[this.oldestIndex];
+    const frames = this.newestIndex > this.oldestIndex ? this.newestIndex - this.oldestIndex : this.size - 1;
+    return (frames / elapsed) * 1e3;
+  }
+}

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -107,8 +107,12 @@ export class SolarSystemModel {
   }
 
   update(ctx: CanvasRenderingContext2D, settings: Settings) {
-    if (settings.play) this.incrementKinematics(settings.dt);
     this.fpsCounter.update();
+    if (settings.play) {
+      const dt = (1 / this.fpsCounter.fps()) * settings.playbackSpeed;
+      console.log(dt);
+      this.incrementKinematics(dt);
+    }
     this.updateCenter(settings); // NOTE: must happen after kinematics are incremented and before controls are updated
     this.controls.update();
     this.firmament.update(this.camera.position, this.controls.target);
@@ -217,7 +221,7 @@ export class SolarSystemModel {
     // TODO: this algorithm could be improved; 1 hour is not always safe for e.g. LEO satellites of Earth, which have
     //  orbital periods of ~90 minutes. It is also overzealous to subdivide like this for orbits with longer periods
     this.time += dt;
-    const nIterations = Math.ceil(dt / this.maxSafeDt);
+    const nIterations = Math.ceil(Math.abs(dt) / this.maxSafeDt);
     const safeDt = dt / nIterations;
     Array(nIterations)
       .fill(null)

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -14,6 +14,7 @@ import { notNullish } from '../utils.ts';
 import { isOffScreen } from './canvas.ts';
 import { CAMERA_INIT, SCALE_FACTOR, SUNLIGHT_COLOR } from './constants.ts';
 import { Firmament } from './Firmament.ts';
+import { FrameRateCounter } from './FrameRateCounter.ts';
 import { KeplerianBody } from './KeplerianBody.ts';
 import { OrbitalRegime } from './OrbitalRegime.ts';
 
@@ -27,6 +28,7 @@ export class SolarSystemModel {
   private readonly lights: Array<Light>;
   private readonly firmament: Firmament;
   private readonly regimes: Array<OrbitalRegime>;
+  private readonly fpsCounter: FrameRateCounter;
   private time: number = 0;
   private bodies: Record<string, KeplerianBody>;
 
@@ -35,6 +37,7 @@ export class SolarSystemModel {
   constructor(container: HTMLElement, settings: Settings) {
     this.scene = new Scene();
     this.resolution = new Vector2(container.clientWidth, container.clientHeight);
+    this.fpsCounter = new FrameRateCounter();
 
     const sunLight = new PointLight(SUNLIGHT_COLOR, 1e5); // high intensity manually tuned
     sunLight.position.set(0, 0, 0);
@@ -97,6 +100,7 @@ export class SolarSystemModel {
   getModelState(): ModelState {
     return {
       time: this.time,
+      fps: this.fpsCounter.fps(),
       metersPerPx: this.getMetersPerPixel(),
       vernalEquinox: this.getVernalEquinox(),
     };
@@ -104,6 +108,7 @@ export class SolarSystemModel {
 
   update(ctx: CanvasRenderingContext2D, settings: Settings) {
     if (settings.play) this.incrementKinematics(settings.dt);
+    this.fpsCounter.update();
     this.updateCenter(settings); // NOTE: must happen after kinematics are incremented and before controls are updated
     this.controls.update();
     this.firmament.update(this.camera.position, this.controls.target);

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -110,7 +110,7 @@ export class SolarSystemModel {
     this.fpsCounter.update();
     const fps = this.fpsCounter.fps();
     if (fps == null) return; // still initializing
-    if (settings.play) this.incrementKinematics((1 / fps) * settings.playbackSpeed);
+    if (settings.play) this.incrementKinematics((1 / fps) * settings.speed);
     this.updateCenter(settings); // NOTE: must happen after kinematics are incremented and before controls are updated
     this.controls.update();
     this.firmament.update(this.camera.position, this.controls.target);

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -108,11 +108,9 @@ export class SolarSystemModel {
 
   update(ctx: CanvasRenderingContext2D, settings: Settings) {
     this.fpsCounter.update();
-    if (settings.play) {
-      const dt = (1 / this.fpsCounter.fps()) * settings.playbackSpeed;
-      console.log(dt);
-      this.incrementKinematics(dt);
-    }
+    const fps = this.fpsCounter.fps();
+    if (fps == null) return; // still initializing
+    if (settings.play) this.incrementKinematics((1 / fps) * settings.playbackSpeed);
     this.updateCenter(settings); // NOTE: must happen after kinematics are incremented and before controls are updated
     this.controls.update();
     this.firmament.update(this.camera.position, this.controls.target);

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -19,6 +19,7 @@ export type Settings = {
 // these values are readonly; driven by the model
 export type ModelState = {
   time: number; // seconds
+  fps: number;
   metersPerPx: number; // describes zoom
   vernalEquinox: Point3; // direction of the Vernal Equinox
 };
@@ -54,6 +55,7 @@ export const initialState: AppState = {
   // set by model on update
   model: {
     time: 0,
+    fps: 0,
     metersPerPx: 1,
     vernalEquinox: [1, 0, 0],
   },

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -61,11 +61,4 @@ export const initialState: AppState = {
   },
 };
 
-export function clampSettings({ speed, ...settings }: Settings): Settings {
-  return {
-    ...settings,
-    speed: Math.min(Math.max(speed, -1e8), 1e8),
-  };
-}
-
 export type UpdateSettings = (update: Partial<Settings> | ((prev: Settings) => Settings)) => void;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -19,7 +19,7 @@ export type Settings = {
 // these values are readonly; driven by the model
 export type ModelState = {
   time: number; // seconds
-  fps: number;
+  fps: number | null; // null while initializing
   metersPerPx: number; // describes zoom
   vernalEquinox: Point3; // direction of the Vernal Equinox
 };
@@ -55,10 +55,17 @@ export const initialState: AppState = {
   // set by model on update
   model: {
     time: 0,
-    fps: 0,
+    fps: null,
     metersPerPx: 1,
     vernalEquinox: [1, 0, 0],
   },
 };
+
+export function clampSettings({ playbackSpeed, ...settings }: Settings): Settings {
+  return {
+    ...settings,
+    playbackSpeed: Math.min(Math.max(playbackSpeed, -1e8), 1e8),
+  };
+}
 
 export type UpdateSettings = (update: Partial<Settings> | ((prev: Settings) => Settings)) => void;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -5,7 +5,7 @@ import { CelestialBody, CelestialBodyType, Epoch, HeliocentricOrbitalRegime, Poi
 export type Settings = {
   epoch: Epoch;
   play: boolean;
-  playbackSpeed: number; // multiplier over real time
+  speed: number; // multiplier over real time
   drawTail: boolean;
   drawOrbit: boolean;
   drawLabel: boolean;
@@ -33,7 +33,7 @@ export const initialState: AppState = {
   settings: {
     epoch: nowEpoch(),
     play: true,
-    playbackSpeed: 1, // real time
+    speed: 1, // real time
     drawTail: false,
     drawOrbit: true,
     drawLabel: true,
@@ -61,10 +61,10 @@ export const initialState: AppState = {
   },
 };
 
-export function clampSettings({ playbackSpeed, ...settings }: Settings): Settings {
+export function clampSettings({ speed, ...settings }: Settings): Settings {
   return {
     ...settings,
-    playbackSpeed: Math.min(Math.max(playbackSpeed, -1e8), 1e8),
+    speed: Math.min(Math.max(speed, -1e8), 1e8),
   };
 }
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,11 +1,11 @@
 import { SOLAR_SYSTEM } from './bodies.ts';
-import { nowEpoch, Time } from './epoch.ts';
+import { nowEpoch } from './epoch.ts';
 import { CelestialBody, CelestialBodyType, Epoch, HeliocentricOrbitalRegime, Point3 } from './types.ts';
 
 export type Settings = {
   epoch: Epoch;
-  dt: number; // seconds
   play: boolean;
+  playbackSpeed: number; // multiplier over real time
   drawTail: boolean;
   drawOrbit: boolean;
   drawLabel: boolean;
@@ -32,8 +32,8 @@ export type AppState = {
 export const initialState: AppState = {
   settings: {
     epoch: nowEpoch(),
-    dt: 30 * Time.MINUTE,
     play: true,
+    playbackSpeed: 1, // real time
     drawTail: false,
     drawOrbit: true,
     drawLabel: true,
@@ -60,12 +60,5 @@ export const initialState: AppState = {
     vernalEquinox: [1, 0, 0],
   },
 };
-
-export function clampSettings({ dt, ...settings }: Settings): Settings {
-  return {
-    ...settings,
-    dt: Math.min(Math.max(dt, Time.SECOND), 365 * Time.DAY),
-  };
-}
 
 export type UpdateSettings = (update: Partial<Settings> | ((prev: Settings) => Settings)) => void;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,21 +1,28 @@
 import { AU } from './bodies.ts';
+import { Time } from './epoch.ts';
 import { CelestialBody, CelestialBodyType } from './types.ts';
 
 export function pluralize(n: number, unit: string) {
-  return n > 1 || n === 0 ? `${n.toLocaleString()} ${unit}s` : `${n.toLocaleString()} ${unit}`;
+  const nAbs = Math.abs(n);
+  return nAbs > 1 || nAbs < 1 ? `${n.toLocaleString()} ${unit}s` : `${n.toLocaleString()} ${unit}`;
 }
 
-export function humanTimeUnits(t: number): [number, string] {
-  if (t < 60) {
+export function humanTimeUnits(t: number, includeWeekAndMonth = false): [number, string] {
+  const tAbs = Math.abs(t);
+  if (tAbs < Time.MINUTE) {
     return [t, 'second'];
-  } else if (t < 60 * 60) {
-    return [t / 60, 'minute'];
-  } else if (t < 60 * 60 * 24) {
-    return [t / 60 / 60, 'hour'];
-  } else if (t < 60 * 60 * 24 * 365) {
-    return [t / 60 / 60 / 24, 'day'];
+  } else if (tAbs < Time.HOUR) {
+    return [t / Time.MINUTE, 'minute'];
+  } else if (tAbs < Time.DAY) {
+    return [t / Time.HOUR, 'hour'];
+  } else if (tAbs < (includeWeekAndMonth ? Time.WEEK : Time.YEAR)) {
+    return [t / Time.DAY, 'day'];
+  } else if (includeWeekAndMonth && tAbs < Time.MONTH) {
+    return [t / Time.WEEK, 'week'];
+  } else if (includeWeekAndMonth && tAbs < Time.YEAR) {
+    return [t / Time.MONTH, 'month'];
   } else {
-    return [t / 60 / 60 / 24 / 365, 'year'];
+    return [t / Time.YEAR, 'year'];
   }
 }
 


### PR DESCRIPTION
Playback in reverse was a highly requested feature on HackerNews. There were also requests to disambiguate ∆t — this PR uses a multiplier over realtime, like Celestia, defaulting to realtime playback (x1) and supporting minute/hour/day/week/month/year/3 years per second playback speeds.