### PR TITLE
Progressively hide labels when zooming out

### DIFF
--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -36,6 +36,7 @@ type Props = {
 };
 export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings, model }: Props) {
   const date = new Date(Number(epochToDate(settings.epoch)) + model.time * 1000);
+  const dateString = dateToHumanReadable(date);
   const [t, tUnits] = useMemo(() => humanTimeUnits(settings.speed, true), [settings.speed]);
 
   const slowDownDisabled = settings.speed < 0 && settings.speed <= -FASTEST_SPEED;
@@ -50,7 +51,7 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
                 date
               </Text>
             </Group>
-            <Text inherit>{dateToHumanReadable(date)}</Text>
+            <Text inherit>{dateString}</Text>
           </Group>
           <Group gap={8}>
             <Group justify="flex-end" w={40}>

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -238,16 +238,14 @@ export class SolarSystemModel {
     });
   }
 
-  private drawAnnotations(ctx: CanvasRenderingContext2D, { hover, drawLabel }: Settings) {
+  private drawAnnotations(ctx: CanvasRenderingContext2D, { hover, center, drawLabel }: Settings) {
     ctx.clearRect(0, 0, this.resolution.x, this.resolution.y);
     const metersPerPx = this.getMetersPerPixel();
     Object.values(this.bodies).forEach(body => {
       body.drawAnnotations(ctx, this.camera, metersPerPx, drawLabel);
     });
-    const hoverBody = this.bodies[hover ?? ''];
-    if (hoverBody != null) {
-      hoverBody.drawAnnotations(ctx, this.camera, metersPerPx);
-    }
+    this.bodies[center ?? '']?.drawAnnotations(ctx, this.camera, metersPerPx);
+    this.bodies[hover ?? '']?.drawAnnotations(ctx, this.camera, metersPerPx);
   }
 
   private updateCenter({ center }: Settings) {

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -249,6 +249,7 @@ export class SolarSystemModel {
   }
 
   private updateCenter({ center }: Settings) {
+    this.controls.zoomToCursor = center == null;
     if (center == null) return;
     const centerBody = this.bodies[center];
     if (centerBody == null) return;

--- a/src/lib/model/constants.ts
+++ b/src/lib/model/constants.ts
@@ -1,4 +1,4 @@
-import { Point3 } from '../types.ts';
+import { CelestialBodyType, Point3 } from '../types.ts';
 
 // units: meters per 3D scene-space unit (not to be confused with pixels)
 export const SCALE_FACTOR = 1e9; // shrink the scene down to work better with Three.js
@@ -10,4 +10,15 @@ export const CAMERA_INIT = {
   up: [0, 0, 1] as Point3, // z-up
   position: [0, 0, 1e6] as Point3, // very high up
   lookAt: [0, 0, 0] as Point3,
+};
+
+export const MIN_ORBIT_PX_LABEL_VISIBLE: Record<CelestialBodyType, number> = {
+  [CelestialBodyType.STAR]: -1, // always visible
+  [CelestialBodyType.PLANET]: 20, // visible unless very small
+  [CelestialBodyType.MOON]: 25,
+  [CelestialBodyType.SPACECRAFT]: 50,
+  [CelestialBodyType.DWARF_PLANET]: 75,
+  [CelestialBodyType.ASTEROID]: 100,
+  [CelestialBodyType.COMET]: 100,
+  [CelestialBodyType.TRANS_NEPTUNIAN_OBJECT]: 100,
 };


### PR DESCRIPTION
Reduce clutter, particularly in the inner system, by hiding labels unless the orbital ellipses are above a certain threshold, tuned by type.