### PR TITLE
Hide body dots until sufficiently zoomed in

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,13 +6,6 @@ publish = "dist"
 [build.environment]
 NODE_VERSION = "20"
 
-[build.processing]
-skip_processing = false
-
-[build.processing.js]
-bundle = false
-minify = false
-
 [[redirects]]
 force = true
 from = '/api/*'

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,13 @@ publish = "dist"
 [build.environment]
 NODE_VERSION = "20"
 
+[build.processing]
+skip_processing = false
+
+[build.processing.js]
+bundle = false
+minify = false
+
 [[redirects]]
 force = true
 from = '/api/*'

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -136,7 +136,8 @@ export class KeplerianBody extends KinematicBody {
   // show dot only when the orbit is larger than the dot itself; helps selectively hide moons until zoomed
   private shouldDrawDot(metersPerPx: number) {
     const longAxisPx = (this.body.elements.semiMajorAxis * 2) / metersPerPx;
-    return this.focused || this.hovered || (this.visible && longAxisPx > this.dotRadius);
+    const isStar = this.body.type === CelestialBodyType.STAR; // always draw for stars
+    return this.focused || this.hovered || isStar || (this.visible && longAxisPx > this.dotRadius);
   }
 
   // progressively hide labels as you zoom out, prioritizing certain types (e.g. planets) over others (e.g. asteroids)

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -28,6 +28,7 @@ export class KeplerianBody extends KinematicBody {
   private readonly dotRadius: number;
   private readonly labelBox = new Box2();
   private readonly screenPoint = new Vector2(); // reuse for efficiency
+  private readonly labelSize: Record<string /* font */, [number, number] /* w, h */> = {}; // cache for efficiency
 
   private visible: boolean = false;
   private hovered: boolean = false;
@@ -90,8 +91,11 @@ export class KeplerianBody extends KinematicBody {
     const label = this.body.shortName ?? this.body.name;
     const fontSize = this.hovered ? '14px' : '12px';
     ctx.font = `${fontSize} ${LABEL_FONT_FAMILY}`;
-    const { width: textWidthPx, actualBoundingBoxAscent: textHeightPx } = ctx.measureText(label);
-    const textPx: Point2 = [textWidthPx, textHeightPx];
+    if (this.labelSize[ctx.font] == null) {
+      const { width: textWidthPx, actualBoundingBoxAscent: textHeightPx } = ctx.measureText(label);
+      this.labelSize[ctx.font] = [textWidthPx, textHeightPx];
+    }
+    const textPx = this.labelSize[ctx.font];
     const canvasPx = getCanvasPixels(ctx);
 
     // body is off-screen; draw a pointer

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -129,11 +129,13 @@ export class KeplerianBody extends KinematicBody {
     return settings.hover === id || settings.center === id || settings.visibleTypes.has(this.body.type);
   }
 
+  // show dot only when the orbit is larger than the dot itself; helps selectively hide moons until zoomed
   private shouldDrawDot(metersPerPx: number) {
     const longAxisPx = (this.body.elements.semiMajorAxis * 2) / metersPerPx;
     return this.focused || this.hovered || (this.visible && longAxisPx > this.dotRadius);
   }
 
+  // progressively hide labels as you zoom out, prioritizing certain types (e.g. planets) over others (e.g. asteroids)
   private shouldDrawLabel(metersPerPx: number) {
     const longAxisPx = (this.body.elements.semiMajorAxis * 2) / metersPerPx;
     const minLongAxisPx = MIN_ORBIT_PX_LABEL_VISIBLE[this.body.type];

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -100,7 +100,7 @@ export class KeplerianBody extends KinematicBody {
     } else {
       const baseRadius = this.body.radius / metersPerPx;
       const bodyRadius = this.hovered ? baseRadius * HOVER_SCALE_FACTOR : baseRadius;
-      if (bodyRadius < this.dotRadius) {
+      if (bodyRadius < this.dotRadius && this.shouldDrawDot(metersPerPx)) {
         drawDotAtLocation(ctx, this.body.color, [bodyXpx, bodyYpx], this.dotRadius);
       }
       if (drawLabel && this.shouldDrawLabel(metersPerPx)) {
@@ -127,6 +127,11 @@ export class KeplerianBody extends KinematicBody {
   isVisible(settings: Settings) {
     const id = this.body.id;
     return settings.hover === id || settings.center === id || settings.visibleTypes.has(this.body.type);
+  }
+
+  private shouldDrawDot(metersPerPx: number) {
+    const longAxisPx = (this.body.elements.semiMajorAxis * 2) / metersPerPx;
+    return this.focused || this.hovered || (this.visible && longAxisPx > this.dotRadius);
   }
 
   private shouldDrawLabel(metersPerPx: number) {

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -7,7 +7,6 @@ import {
   drawDotAtLocation,
   drawLabelAtLocation,
   drawOffscreenIndicator,
-  getCanvasPixels,
   isOffScreen,
   LABEL_FONT_FAMILY,
 } from './canvas.ts';
@@ -82,7 +81,13 @@ export class KeplerianBody extends KinematicBody {
   }
 
   // draw the dot and label for this body
-  drawAnnotations(ctx: CanvasRenderingContext2D, camera: OrthographicCamera, metersPerPx: number, drawLabel = true) {
+  drawAnnotations(
+    ctx: CanvasRenderingContext2D,
+    camera: OrthographicCamera,
+    metersPerPx: number,
+    canvasPx: Point2,
+    drawLabel = true
+  ) {
     if (!this.visible) return;
 
     const [bodyXpx, bodyYpxInverted] = this.getScreenPosition(camera, this.resolution);
@@ -96,7 +101,6 @@ export class KeplerianBody extends KinematicBody {
       this.labelSize[ctx.font] = [textWidthPx, textHeightPx];
     }
     const textPx = this.labelSize[ctx.font];
-    const canvasPx = getCanvasPixels(ctx);
 
     // body is off-screen; draw a pointer
     if (isOffScreen([bodyXpx, bodyYpx], [this.resolution.x, this.resolution.y])) {

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -10,7 +10,7 @@ import { ORBITAL_REGIMES } from '../regimes.ts';
 import { ModelState, Settings } from '../state.ts';
 import { CelestialBody, CelestialBodyType, Point2, Point3 } from '../types.ts';
 import { notNullish } from '../utils.ts';
-import { isOffScreen } from './canvas.ts';
+import { getCanvasPixels, isOffScreen } from './canvas.ts';
 import { CAMERA_INIT, SCALE_FACTOR, SUNLIGHT_COLOR } from './constants.ts';
 import { Firmament } from './Firmament.ts';
 import { FrameRateCounter } from './FrameRateCounter.ts';
@@ -242,6 +242,7 @@ export class SolarSystemModel {
   private drawAnnotations(ctx: CanvasRenderingContext2D, settings: Settings) {
     ctx.clearRect(0, 0, this.resolution.x, this.resolution.y);
     const metersPerPx = this.getMetersPerPixel();
+    const canvasPx = getCanvasPixels(ctx);
     Object.values(this.bodies)
       .map<[KeplerianBody, number]>(body => {
         const distance = !body.isVisible(settings)
@@ -256,7 +257,7 @@ export class SolarSystemModel {
       .filter(([, distance]) => distance > 0)
       .sort(([, aDistance], [, bDistance]) => bDistance - aDistance)
       .forEach(([body]) => {
-        body.drawAnnotations(ctx, this.camera, metersPerPx, settings.drawLabel);
+        body.drawAnnotations(ctx, this.camera, metersPerPx, canvasPx, settings.drawLabel);
       });
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,4 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [react()],
   assetsInclude: ['assets/*.{png,gif,jpg,ttf}'],
-  build: { sourcemap: true },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   assetsInclude: ['assets/*.{png,gif,jpg,ttf}'],
+  build: { sourcemap: true },
 });


### PR DESCRIPTION
Helps to hide the dots for e.g. moons until you're zoomed into the planet enough to actually see them.

Also doing some performance tuning.