### PR TITLE
Controls to set simulation to a target date

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.33.1",
     "@mantine/core": "^7.14.3",
+    "@mantine/dates": "^7.15.3",
     "@mantine/hooks": "^7.14.3",
     "@mantine/spotlight": "^7.15.2",
     "@netlify/blobs": "^8.1.0",
@@ -22,6 +23,7 @@
     "@tabler/icons-react": "^3.24.0",
     "@tanstack/react-query": "^5.62.8",
     "@types/ramda": "^0.30.2",
+    "dayjs": "^1.11.13",
     "eslint-plugin-stylelint": "^0.1.1",
     "linkedom": "^0.18.6",
     "prettier": "^3.4.2",

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mantine/core';
-import { useIsSmallDisplay } from '../../hooks/useIsSmallDisplay.ts';
 import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
 import { Epoch } from '../../lib/types.ts';
 import { GeneralControls } from './GeneralControls.tsx';
@@ -16,22 +15,17 @@ type Props = {
   reset: () => void;
 };
 export function Controls({ settings, updateSettings, model, setEpoch, reset }: Props) {
-  const isSmallDisplay = useIsSmallDisplay();
   return (
     <>
       <Box pos="absolute" bottom={pad} left={pad}>
         <TimeControls settings={settings} updateSettings={updateSettings} model={model} setEpoch={setEpoch} />
       </Box>
 
-      <Box
-        pos="absolute"
-        bottom={pad}
-        {...(isSmallDisplay ? { right: pad } : { left: '50%', style: { transform: 'translate(-50%, 0)' } })}
-      >
+      <Box pos="absolute" bottom={pad} right={pad}>
         <GeneralControls settings={settings} updateSettings={updateSettings} reset={reset} />
       </Box>
 
-      <Box pos="absolute" right={pad} {...(isSmallDisplay ? { top: pad } : { bottom: pad })}>
+      <Box pos="absolute" right={pad} top={pad}>
         <ScaleControls metersPerPx={model.metersPerPx} vernalEquinox={model.vernalEquinox} />
       </Box>
     </>

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mantine/core';
 import { useIsSmallDisplay } from '../../hooks/useIsSmallDisplay.ts';
 import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
+import { Epoch } from '../../lib/types.ts';
 import { GeneralControls } from './GeneralControls.tsx';
 import { ScaleControls } from './ScaleControls.tsx';
 import { TimeControls } from './TimeControls.tsx';
@@ -11,14 +12,15 @@ type Props = {
   settings: Settings;
   updateSettings: UpdateSettings;
   model: ModelState;
+  setEpoch: (epoch: Epoch) => void;
   reset: () => void;
 };
-export function Controls({ settings, updateSettings, model, reset }: Props) {
+export function Controls({ settings, updateSettings, model, setEpoch, reset }: Props) {
   const isSmallDisplay = useIsSmallDisplay();
   return (
     <>
       <Box pos="absolute" bottom={pad} left={pad}>
-        <TimeControls settings={settings} updateSettings={updateSettings} model={model} />
+        <TimeControls settings={settings} updateSettings={updateSettings} model={model} setEpoch={setEpoch} />
       </Box>
 
       <Box

--- a/src/components/Controls/DirectionIndicator.tsx
+++ b/src/components/Controls/DirectionIndicator.tsx
@@ -11,6 +11,8 @@ export function DirectionIndicator({ vernalEquinox }: Props) {
   const width = iconSize + pad * 2;
   return (
     <Tooltip
+      offset={0}
+      position="bottom-end"
       label={
         <Group gap={4}>
           <Text inherit>Vernal Equinox</Text>

--- a/src/components/Controls/EpochPopover.tsx
+++ b/src/components/Controls/EpochPopover.tsx
@@ -1,36 +1,51 @@
 import { Button, Popover } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 import { dateToEpoch, dateToHumanReadable } from '../../lib/epoch.ts';
+import { LABEL_FONT_FAMILY } from '../../lib/model/canvas.ts';
 import { Epoch } from '../../lib/types.ts';
+
+const JAN_1_1900 = new Date(1900, 0, 1);
+const JAN_1_2200 = new Date(2200, 0, 1);
 
 type Props = {
   date: Date;
   setEpoch: (epoch: Epoch) => void;
 };
 export const EpochPopover = memo(function EpochPopoverComponent({ date, setEpoch }: Props) {
+  const hasInteracted = useRef(false);
   return (
-    <Popover position="bottom">
+    <Popover
+      position="bottom"
+      onExitTransitionEnd={() => {
+        hasInteracted.current = false;
+      }}
+    >
       <Popover.Target>
-        <Button size="compact-xs" fw="normal" color="gray" variant="subtle">
+        <Button ff={LABEL_FONT_FAMILY} size="compact-xs" color="gray" variant="subtle">
           {dateToHumanReadable(date)}
         </Button>
       </Popover.Target>
-      <Popover.Dropdown>
+      <Popover.Dropdown mih={277} bg="black">
         <DatePicker
+          ff={LABEL_FONT_FAMILY}
           size="xs"
           yearLabelFormat="YYYY"
           yearsListFormat="YYYY"
           monthsListFormat="MM (MMM)"
           monthLabelFormat="YYYY-MM"
+          minDate={JAN_1_1900}
+          maxDate={JAN_1_2200}
+          date={hasInteracted.current ? undefined : date}
           value={date}
           defaultDate={date}
+          onClick={() => {
+            hasInteracted.current = true;
+          }}
           onChange={value => {
             if (value != null) setEpoch(dateToEpoch('TODO', value));
           }}
-          getDayProps={() => ({
-            weekend: false,
-          })}
+          weekendDays={[]}
         />
       </Popover.Dropdown>
     </Popover>

--- a/src/components/Controls/EpochPopover.tsx
+++ b/src/components/Controls/EpochPopover.tsx
@@ -1,0 +1,38 @@
+import { Button, Popover } from '@mantine/core';
+import { DatePicker } from '@mantine/dates';
+import { memo } from 'react';
+import { dateToEpoch, dateToHumanReadable } from '../../lib/epoch.ts';
+import { Epoch } from '../../lib/types.ts';
+
+type Props = {
+  date: Date;
+  setEpoch: (epoch: Epoch) => void;
+};
+export const EpochPopover = memo(function EpochPopoverComponent({ date, setEpoch }: Props) {
+  return (
+    <Popover position="bottom">
+      <Popover.Target>
+        <Button size="compact-xs" fw="normal" color="gray" variant="subtle">
+          {dateToHumanReadable(date)}
+        </Button>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <DatePicker
+          size="xs"
+          yearLabelFormat="YYYY"
+          yearsListFormat="YYYY"
+          monthsListFormat="MM (MMM)"
+          monthLabelFormat="YYYY-MM"
+          value={date}
+          defaultDate={date}
+          onChange={value => {
+            if (value != null) setEpoch(dateToEpoch('TODO', value));
+          }}
+          getDayProps={() => ({
+            weekend: false,
+          })}
+        />
+      </Popover.Dropdown>
+    </Popover>
+  );
+});

--- a/src/components/Controls/EpochPopover.tsx
+++ b/src/components/Controls/EpochPopover.tsx
@@ -1,8 +1,8 @@
 import { Button, Popover } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 import { memo, useRef } from 'react';
+import { LABEL_FONT_FAMILY } from '../../lib/canvas.ts';
 import { dateToEpoch, dateToHumanReadable } from '../../lib/epoch.ts';
-import { LABEL_FONT_FAMILY } from '../../lib/model/canvas.ts';
 import { Epoch } from '../../lib/types.ts';
 
 const JAN_1_1900 = new Date(1900, 0, 1);

--- a/src/components/Controls/EpochPopover.tsx
+++ b/src/components/Controls/EpochPopover.tsx
@@ -2,7 +2,7 @@ import { Button, Popover } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 import { memo, useRef } from 'react';
 import { LABEL_FONT_FAMILY } from '../../lib/canvas.ts';
-import { dateToEpoch, dateToHumanReadable } from '../../lib/epoch.ts';
+import { dateToEpoch, dateToHumanReadable, dateToJulianDay } from '../../lib/epoch.ts';
 import { Epoch } from '../../lib/types.ts';
 
 const JAN_1_1900 = new Date(1900, 0, 1);
@@ -43,7 +43,7 @@ export const EpochPopover = memo(function EpochPopoverComponent({ date, setEpoch
             hasInteracted.current = true;
           }}
           onChange={value => {
-            if (value != null) setEpoch(dateToEpoch('TODO', value));
+            if (value != null) setEpoch(dateToEpoch(dateToJulianDay(value), value));
           }}
           weekendDays={[]}
         />

--- a/src/components/Controls/ScaleIndicator.tsx
+++ b/src/components/Controls/ScaleIndicator.tsx
@@ -1,5 +1,6 @@
 import { Box, Paper, Stack, Text } from '@mantine/core';
 import { AU } from '../../lib/bodies.ts';
+import { LABEL_FONT_FAMILY } from '../../lib/model/canvas.ts';
 import { ModelState } from '../../lib/state.ts';
 
 type Props = Pick<ModelState, 'metersPerPx'>;
@@ -18,7 +19,7 @@ export function ScaleIndicator({ metersPerPx }: Props) {
     <Paper p={4} bg="transparent" radius="md" style={{ backdropFilter: 'blur(4px)' }}>
       <Stack gap={4} align="flex-end">
         <Box w={scaleWidthM / metersPerPx} h={1} style={{ backgroundColor: 'var(--mantine-color-gray-light-color)' }} />
-        <Text size="xs">
+        <Text size="xs" ff={LABEL_FONT_FAMILY}>
           {scaleDisplay.toLocaleString()} {scaleUnits}
         </Text>
       </Stack>

--- a/src/components/Controls/ScaleIndicator.tsx
+++ b/src/components/Controls/ScaleIndicator.tsx
@@ -1,6 +1,6 @@
 import { Box, Paper, Stack, Text } from '@mantine/core';
 import { AU } from '../../lib/bodies.ts';
-import { LABEL_FONT_FAMILY } from '../../lib/model/canvas.ts';
+import { LABEL_FONT_FAMILY } from '../../lib/canvas.ts';
 import { ModelState } from '../../lib/state.ts';
 
 type Props = Pick<ModelState, 'metersPerPx'>;

--- a/src/components/Controls/ScaleIndicator.tsx
+++ b/src/components/Controls/ScaleIndicator.tsx
@@ -19,7 +19,7 @@ export function ScaleIndicator({ metersPerPx }: Props) {
     <Paper p={4} bg="transparent" radius="md" style={{ backdropFilter: 'blur(4px)' }}>
       <Stack gap={4} align="flex-end">
         <Box w={scaleWidthM / metersPerPx} h={1} style={{ backgroundColor: 'var(--mantine-color-gray-light-color)' }} />
-        <Text size="xs" ff={LABEL_FONT_FAMILY}>
+        <Text size="xs" c="dimmed" ff={LABEL_FONT_FAMILY}>
           {scaleDisplay.toLocaleString()} {scaleUnits}
         </Text>
       </Stack>

--- a/src/components/Controls/SelectOmnibox.tsx
+++ b/src/components/Controls/SelectOmnibox.tsx
@@ -3,7 +3,7 @@ import { Spotlight, spotlight } from '@mantine/spotlight';
 import { IconSearch } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 import { useModifierKey } from '../../hooks/useModifierKey.ts';
-import { LABEL_FONT_FAMILY } from '../../lib/model/canvas.ts';
+import { LABEL_FONT_FAMILY } from '../../lib/canvas.ts';
 import { ORBITAL_REGIMES, orbitalRegimeDisplayName } from '../../lib/regimes.ts';
 import { Settings, UpdateSettings } from '../../lib/state.ts';
 import { CelestialBody } from '../../lib/types.ts';

--- a/src/components/Controls/SelectOmnibox.tsx
+++ b/src/components/Controls/SelectOmnibox.tsx
@@ -3,6 +3,7 @@ import { Spotlight, spotlight } from '@mantine/spotlight';
 import { IconSearch } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 import { useModifierKey } from '../../hooks/useModifierKey.ts';
+import { LABEL_FONT_FAMILY } from '../../lib/model/canvas.ts';
 import { ORBITAL_REGIMES, orbitalRegimeDisplayName } from '../../lib/regimes.ts';
 import { Settings, UpdateSettings } from '../../lib/state.ts';
 import { CelestialBody } from '../../lib/types.ts';
@@ -28,6 +29,7 @@ export function SelectOmnibox({ settings, updateSettings }: Props) {
             key={`${body.name}-${i}`}
             label={body.name}
             className={styles.Action}
+            ff={LABEL_FONT_FAMILY}
             leftSection={
               // TODO: lazy load thumbnails for visible objects only
               <Box miw={24}>
@@ -35,7 +37,7 @@ export function SelectOmnibox({ settings, updateSettings }: Props) {
               </Box>
             }
             rightSection={
-              <Text c="dimmed" size="xs">
+              <Text c="dimmed" size="xs" ff={LABEL_FONT_FAMILY}>
                 {celestialBodyTypeDescription(body)}
               </Text>
             }
@@ -54,8 +56,9 @@ export function SelectOmnibox({ settings, updateSettings }: Props) {
             key={`${id}-${i}`}
             label={orbitalRegimeDisplayName(id)}
             className={styles.Action}
+            ff={LABEL_FONT_FAMILY}
             rightSection={
-              <Text c="dimmed" size="xs">
+              <Text c="dimmed" size="xs" ff={LABEL_FONT_FAMILY}>
                 Orbital Regime
               </Text>
             }
@@ -92,6 +95,7 @@ export function SelectOmnibox({ settings, updateSettings }: Props) {
         >
           <Spotlight.Search
             placeholder="Enter name..."
+            styles={{ input: { fontFamily: LABEL_FONT_FAMILY } }}
             leftSection={<IconSearch stroke={1.5} />}
             rightSection={
               modifierKey != null ? (
@@ -102,15 +106,17 @@ export function SelectOmnibox({ settings, updateSettings }: Props) {
             }
           />
           <Spotlight.ActionsList style={{ overflow: 'auto' }}>
-            {bodyItems.length + regimeItems.length < 1 && <Spotlight.Empty>Nothing found...</Spotlight.Empty>}
+            {bodyItems.length + regimeItems.length < 1 && (
+              <Spotlight.Empty ff={LABEL_FONT_FAMILY}>Nothing found...</Spotlight.Empty>
+            )}
             {bodyItems.length > 0 && (
-              <Spotlight.ActionsGroup label="Celestial Bodies">
+              <Spotlight.ActionsGroup ff={LABEL_FONT_FAMILY} label="Celestial Bodies">
                 <Box pb="xs" />
                 {bodyItems}
               </Spotlight.ActionsGroup>
             )}
             {regimeItems.length > 0 && (
-              <Spotlight.ActionsGroup label="Orbital Regimes">
+              <Spotlight.ActionsGroup ff={LABEL_FONT_FAMILY} label="Orbital Regimes">
                 <Box pb="xs" />
                 {regimeItems}
               </Spotlight.ActionsGroup>

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -1,10 +1,12 @@
 import { ActionIcon, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { IconPlayerPlay, IconPlayerStop, IconPlayerTrackNext, IconPlayerTrackPrev } from '@tabler/icons-react';
 import { memo, useMemo } from 'react';
-import { dateToHumanReadable, epochToDate, Time } from '../../lib/epoch.ts';
+import { epochToDate, Time } from '../../lib/epoch.ts';
 import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
+import { Epoch } from '../../lib/types.ts';
 import { humanTimeUnits, pluralize } from '../../lib/utils.ts';
 import { buttonGap, iconSize } from './constants.ts';
+import { EpochPopover } from './EpochPopover.tsx';
 
 const SPEEDS = [Time.SECOND, Time.MINUTE, Time.HOUR, Time.DAY, Time.WEEK, Time.MONTH, Time.YEAR, Time.YEAR * 3];
 const FASTEST_SPEED = SPEEDS[SPEEDS.length - 1];
@@ -33,10 +35,11 @@ type Props = {
   settings: Settings;
   updateSettings: UpdateSettings;
   model: ModelState;
+  setEpoch: (epoch: Epoch) => void;
 };
-export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings, model }: Props) {
+export const TimeControls = memo(function TimeControlsComponent({ settings, updateSettings, model, setEpoch }: Props) {
   const date = new Date(Number(epochToDate(settings.epoch)) + model.time * 1000);
-  const dateString = dateToHumanReadable(date);
+  const dateRounded = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   const [t, tUnits] = useMemo(() => humanTimeUnits(settings.speed, true), [settings.speed]);
 
   const slowDownDisabled = settings.speed < 0 && settings.speed <= -FASTEST_SPEED;
@@ -51,7 +54,7 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
                 date
               </Text>
             </Group>
-            <Text inherit>{dateString}</Text>
+            <EpochPopover date={dateRounded} setEpoch={setEpoch} />
           </Group>
           <Group gap={8}>
             <Group justify="flex-end" w={40}>

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -65,7 +65,7 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
       <Paper pr={buttonGap} py={2} radius="md">
         <Stack gap={2} align="flex-start" fz="xs">
           <EpochPopover date={dateRounded} setEpoch={setEpoch} />
-          <Text inherit ml={8} c="dimmed" ff={LABEL_FONT_FAMILY}>
+          <Text ml={8} inherit c="dimmed" ff={LABEL_FONT_FAMILY}>
             {tUnits === 'second' && t === 1 ? 'realtime' : `${pluralize(t, tUnits)} / second`}
           </Text>
         </Stack>

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -1,8 +1,8 @@
 import { ActionIcon, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { IconPlayerPlay, IconPlayerStop, IconPlayerTrackNext, IconPlayerTrackPrev } from '@tabler/icons-react';
 import { memo, useMemo } from 'react';
+import { LABEL_FONT_FAMILY } from '../../lib/canvas.ts';
 import { epochToDate, Time } from '../../lib/epoch.ts';
-import { LABEL_FONT_FAMILY } from '../../lib/model/canvas.ts';
 import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
 import { Epoch } from '../../lib/types.ts';
 import { humanTimeUnits, pluralize } from '../../lib/utils.ts';

--- a/src/components/Controls/TimeControls.tsx
+++ b/src/components/Controls/TimeControls.tsx
@@ -2,13 +2,29 @@ import { ActionIcon, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
 import { IconPlayerPlay, IconPlayerStop, IconPlayerTrackNext, IconPlayerTrackPrev } from '@tabler/icons-react';
 import { memo, useMemo } from 'react';
 import { epochToDate, Time } from '../../lib/epoch.ts';
+import { LABEL_FONT_FAMILY } from '../../lib/model/canvas.ts';
 import { ModelState, Settings, UpdateSettings } from '../../lib/state.ts';
 import { Epoch } from '../../lib/types.ts';
 import { humanTimeUnits, pluralize } from '../../lib/utils.ts';
 import { buttonGap, iconSize } from './constants.ts';
 import { EpochPopover } from './EpochPopover.tsx';
 
-const SPEEDS = [Time.SECOND, Time.MINUTE, Time.HOUR, Time.DAY, Time.WEEK, Time.MONTH, Time.YEAR, Time.YEAR * 3];
+const SPEEDS = [
+  Time.SECOND,
+  Time.MINUTE,
+  Time.HOUR,
+  Time.HOUR * 6,
+  Time.HOUR * 12,
+  Time.DAY,
+  Time.DAY * 3,
+  Time.WEEK,
+  Time.MONTH,
+  Time.MONTH * 3,
+  Time.MONTH * 6,
+  Time.YEAR,
+  Time.YEAR * 2,
+  Time.YEAR * 3,
+];
 const FASTEST_SPEED = SPEEDS[SPEEDS.length - 1];
 
 function findNextSpeed(speed: number, direction: 'faster' | 'slower') {
@@ -45,25 +61,13 @@ export const TimeControls = memo(function TimeControlsComponent({ settings, upda
   const slowDownDisabled = settings.speed < 0 && settings.speed <= -FASTEST_SPEED;
   const speedUpDisabled = settings.speed > 0 && settings.speed >= FASTEST_SPEED;
   return (
-    <Stack gap={4}>
-      <Paper radius="md">
-        <Stack gap={2} fz="xs">
-          <Group gap={8}>
-            <Group justify="flex-end" w={40}>
-              <Text inherit c="dimmed">
-                date
-              </Text>
-            </Group>
-            <EpochPopover date={dateRounded} setEpoch={setEpoch} />
-          </Group>
-          <Group gap={8}>
-            <Group justify="flex-end" w={40}>
-              <Text inherit c="dimmed">
-                speed
-              </Text>
-            </Group>
-            <Text inherit>{tUnits === 'second' && t === 1 ? 'realtime' : `${pluralize(t, tUnits)} / second`}</Text>
-          </Group>
+    <Stack gap={buttonGap}>
+      <Paper pr={buttonGap} py={2} radius="md">
+        <Stack gap={2} align="flex-start" fz="xs">
+          <EpochPopover date={dateRounded} setEpoch={setEpoch} />
+          <Text inherit ml={8} c="dimmed" ff={LABEL_FONT_FAMILY}>
+            {tUnits === 'second' && t === 1 ? 'realtime' : `${pluralize(t, tUnits)} / second`}
+          </Text>
         </Stack>
       </Paper>
 

--- a/src/components/Controls/VisibilityControls.tsx
+++ b/src/components/Controls/VisibilityControls.tsx
@@ -1,5 +1,6 @@
 import { ActionIcon, Group, Menu, Tooltip } from '@mantine/core';
 import { IconCircle, IconCircleFilled, IconEyeCog } from '@tabler/icons-react';
+import { orbitalRegimeDisplayName } from '../../lib/regimes.ts';
 import { Settings, UpdateSettings } from '../../lib/state.ts';
 import { CelestialBodyType, CelestialBodyTypes, HeliocentricOrbitalRegime } from '../../lib/types.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
@@ -49,7 +50,7 @@ export function VisibilityControls({ settings, updateSettings }: Props) {
           <Menu.Item key={regime} onClick={() => toggleVisibleRegime(regime)}>
             <Group gap="xs" align="center">
               {settings.visibleRegimes.has(regime) ? <IconCircleFilled size={14} /> : <IconCircle size={14} />}
-              {regime}
+              {orbitalRegimeDisplayName(regime)}
             </Group>
           </Menu.Item>
         ))}

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -61,7 +61,7 @@ export function SolarSystem() {
   function setEpoch(epoch: Epoch) {
     updateSettings(prev => {
       const newSettings = { ...prev, epoch };
-      model.setEpoch(newSettings);
+      model.reset(newSettings, false);
       return newSettings;
     });
   }

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -7,7 +7,7 @@ import { useSolarSystemModel } from '../hooks/useSolarSystemModel.ts';
 import { DEFAULT_ASTEROID_COLOR } from '../lib/bodies.ts';
 import { ORBITAL_REGIMES } from '../lib/regimes.ts';
 import { initialState, UpdateSettings } from '../lib/state.ts';
-import { CelestialBody, isCelestialBody } from '../lib/types.ts';
+import { CelestialBody, Epoch, isCelestialBody } from '../lib/types.ts';
 import { Controls } from './Controls/Controls.tsx';
 import { FactSheet } from './FactSheet/FactSheet.tsx';
 
@@ -56,6 +56,14 @@ export function SolarSystem() {
   function removeBody(id: string) {
     updateSettings(prev => ({ ...prev, bodies: prev.bodies.filter(b => b.id !== id) }));
     model.remove(id);
+  }
+
+  function setEpoch(epoch: Epoch) {
+    updateSettings(prev => {
+      const newSettings = { ...prev, epoch };
+      model.setEpoch(newSettings);
+      return newSettings;
+    });
   }
 
   const resetState = useCallback(() => {
@@ -114,7 +122,13 @@ export function SolarSystem() {
           ref={model.canvasRef}
           style={{ height: '100%', width: '100%', position: 'absolute', pointerEvents: 'none' }}
         />
-        <Controls settings={settings} updateSettings={updateSettings} model={appState.model} reset={resetState} />
+        <Controls
+          settings={settings}
+          updateSettings={updateSettings}
+          model={appState.model}
+          setEpoch={setEpoch}
+          reset={resetState}
+        />
       </Box>
       {focusItem != null && (
         <Box

--- a/src/hooks/useSolarSystemModel.ts
+++ b/src/hooks/useSolarSystemModel.ts
@@ -51,7 +51,6 @@ export function useSolarSystemModel() {
     update: (ctx: CanvasRenderingContext2D, settings: Settings) => modelRef.current?.update(ctx, settings),
     add: (settings: Settings, body: CelestialBody) => modelRef.current?.add(settings, body),
     remove: (id: string) => modelRef.current?.remove(id),
-    setEpoch: (settings: Settings) => modelRef.current?.setEpoch(settings),
-    reset: (settings: Settings) => modelRef.current?.reset(settings),
+    reset: (settings: Settings, viewport = true) => modelRef.current?.reset(settings, viewport),
   };
 }

--- a/src/hooks/useSolarSystemModel.ts
+++ b/src/hooks/useSolarSystemModel.ts
@@ -42,31 +42,16 @@ export function useSolarSystemModel() {
     initializeCanvas();
   }
 
-  function update(ctx: CanvasRenderingContext2D, settings: Settings) {
-    modelRef.current?.update(ctx, settings);
-  }
-
-  function add(settings: Settings, body: CelestialBody) {
-    modelRef.current?.add(settings, body);
-  }
-
-  function remove(id: string) {
-    modelRef.current?.remove(id);
-  }
-
-  function reset(settings: Settings) {
-    modelRef.current?.reset(settings);
-  }
-
   return {
     containerRef,
     canvasRef,
     modelRef,
     initialize,
-    update,
-    add,
     resize,
-    remove,
-    reset,
+    update: (ctx: CanvasRenderingContext2D, settings: Settings) => modelRef.current?.update(ctx, settings),
+    add: (settings: Settings, body: CelestialBody) => modelRef.current?.add(settings, body),
+    remove: (id: string) => modelRef.current?.remove(id),
+    setEpoch: (settings: Settings) => modelRef.current?.setEpoch(settings),
+    reset: (settings: Settings) => modelRef.current?.reset(settings),
   };
 }

--- a/src/hooks/useSolarSystemModel.ts
+++ b/src/hooks/useSolarSystemModel.ts
@@ -51,6 +51,6 @@ export function useSolarSystemModel() {
     update: (ctx: CanvasRenderingContext2D, settings: Settings) => modelRef.current?.update(ctx, settings),
     add: (settings: Settings, body: CelestialBody) => modelRef.current?.add(settings, body),
     remove: (id: string) => modelRef.current?.remove(id),
-    reset: (settings: Settings, viewport = true) => modelRef.current?.reset(settings, viewport),
+    reset: (settings: Settings, camera = true) => modelRef.current?.reset(settings, camera),
   };
 }

--- a/src/lib/canvas.ts
+++ b/src/lib/canvas.ts
@@ -1,4 +1,4 @@
-import { Point2 } from '../types.ts';
+import { Point2 } from './types.ts';
 
 export const LABEL_FONT_FAMILY = 'Electrolize, sans-serif';
 

--- a/src/lib/epoch.ts
+++ b/src/lib/epoch.ts
@@ -44,10 +44,10 @@ export function epochToDate({ year, month, day, hour, minute, second }: Epoch): 
 
 export function nowEpoch(): Epoch {
   const now = new Date();
-  return dateToEpoch(getJulianDate(now), now);
+  return dateToEpoch(dateToJulianDay(now), now);
 }
 
-function getJulianDate(date: Date): `JD${string}` {
+export function dateToJulianDay(date: Date): `JD${string}` {
   const { year, month: monthIndex, day, hour, minute, second } = dateToEpoch('', date);
   const month = monthIndex + 1; // JavaScript months are 0-based
   const millisecond = date.getUTCMilliseconds();

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -7,6 +7,7 @@ import {
   drawDotAtLocation,
   drawLabelAtLocation,
   drawOffscreenIndicator,
+  isLabelFontAvailable,
   isOffScreen,
   LABEL_FONT_FAMILY,
 } from './canvas.ts';
@@ -96,12 +97,13 @@ export class KeplerianBody extends KinematicBody {
     const label = this.body.shortName ?? this.body.name;
     const fontSize = this.hovered ? '14px' : '12px';
     ctx.font = `${fontSize} ${LABEL_FONT_FAMILY}`;
-    if (this.labelSize[ctx.font] == null) {
+    let textPx = this.labelSize[ctx.font];
+    if (textPx == null) {
       const { width: textWidthPx, actualBoundingBoxAscent: textHeightPx } = ctx.measureText(label);
-      // TODO: if the primary font hasn't been loaded, this will cache the backup font
-      this.labelSize[ctx.font] = [textWidthPx, textHeightPx];
+      // ensure we are only caching once the primary label font becomes available
+      if (isLabelFontAvailable(ctx)) this.labelSize[ctx.font] = [textWidthPx, textHeightPx];
+      textPx = [textWidthPx, textHeightPx];
     }
-    const textPx = this.labelSize[ctx.font];
 
     // body is off-screen; draw a pointer
     const offscreen = isOffScreen([bodyXpx, bodyYpx], [this.resolution.x, this.resolution.y]);

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -98,14 +98,19 @@ export class KeplerianBody extends KinematicBody {
     ctx.font = `${fontSize} ${LABEL_FONT_FAMILY}`;
     if (this.labelSize[ctx.font] == null) {
       const { width: textWidthPx, actualBoundingBoxAscent: textHeightPx } = ctx.measureText(label);
+      // TODO: if the primary font hasn't been loaded, this will cache the backup font
       this.labelSize[ctx.font] = [textWidthPx, textHeightPx];
     }
     const textPx = this.labelSize[ctx.font];
 
     // body is off-screen; draw a pointer
-    if (isOffScreen([bodyXpx, bodyYpx], [this.resolution.x, this.resolution.y])) {
+    const offscreen = isOffScreen([bodyXpx, bodyYpx], [this.resolution.x, this.resolution.y]);
+    const shouldDrawDot = this.shouldDrawDot(metersPerPx);
+    if (offscreen && shouldDrawDot) {
+      // TODO: how to always draw moon offscreen indicators underneath parent? better yet, don't draw offscreen
+      //  indicators for moons when the parent isn't visible
       drawOffscreenIndicator(ctx, this.body.color, canvasPx, [bodyXpx, bodyYpx]);
-    } else {
+    } else if (!offscreen) {
       const baseRadius = this.body.radius / metersPerPx;
       const bodyRadius = this.hovered ? baseRadius * HOVER_SCALE_FACTOR : baseRadius;
       if (bodyRadius < this.dotRadius && this.shouldDrawDot(metersPerPx)) {

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -1,8 +1,4 @@
 import { Box2, Color, OrthographicCamera, Scene, Vector2, Vector3 } from 'three';
-import { magnitude } from '../physics.ts';
-import { Settings } from '../state.ts';
-import { CelestialBody, CelestialBodyType, Point2 } from '../types.ts';
-import { AxisIndicator } from './AxisIndicator.ts';
 import {
   drawDotAtLocation,
   drawLabelAtLocation,
@@ -10,7 +6,11 @@ import {
   isLabelFontAvailable,
   isOffScreen,
   LABEL_FONT_FAMILY,
-} from './canvas.ts';
+} from '../canvas.ts';
+import { magnitude } from '../physics.ts';
+import { Settings } from '../state.ts';
+import { CelestialBody, CelestialBodyType, Point2 } from '../types.ts';
+import { AxisIndicator } from './AxisIndicator.ts';
 import { HOVER_SCALE_FACTOR, MIN_ORBIT_PX_LABEL_VISIBLE } from './constants.ts';
 import { FocalRadius } from './FocalRadius.ts';
 import { KinematicBody } from './KinematicBody.ts';

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -106,13 +106,11 @@ export class KeplerianBody extends KinematicBody {
     }
 
     // body is off-screen; draw a pointer
-    const offscreen = isOffScreen([bodyXpx, bodyYpx], [this.resolution.x, this.resolution.y]);
-    const shouldDrawDot = this.shouldDrawDot(metersPerPx);
-    if (offscreen && shouldDrawDot) {
+    if (isOffScreen([bodyXpx, bodyYpx], [this.resolution.x, this.resolution.y])) {
       // TODO: how to always draw moon offscreen indicators underneath parent? better yet, don't draw offscreen
       //  indicators for moons when the parent isn't visible
       drawOffscreenIndicator(ctx, this.body.color, canvasPx, [bodyXpx, bodyYpx]);
-    } else if (!offscreen) {
+    } else {
       const baseRadius = this.body.radius / metersPerPx;
       const bodyRadius = this.hovered ? baseRadius * HOVER_SCALE_FACTOR : baseRadius;
       if (bodyRadius < this.dotRadius && this.shouldDrawDot(metersPerPx)) {

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -138,9 +138,9 @@ export class SolarSystemModel {
     toRemove.dispose();
   }
 
-  reset(settings: Settings, viewport = true) {
+  reset(settings: Settings, camera = true) {
     this.time = 0;
-    if (viewport) {
+    if (camera) {
       this.setupCamera();
       this.controls.reset();
     }

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -138,6 +138,12 @@ export class SolarSystemModel {
     toRemove.dispose();
   }
 
+  setEpoch(settings: Settings) {
+    this.time = 0;
+    Object.values(this.bodies).forEach(body => body.dispose());
+    this.bodies = this.createBodies(settings);
+  }
+
   reset(settings: Settings) {
     this.time = 0;
     this.setupCamera();

--- a/src/lib/model/SolarSystemModel.ts
+++ b/src/lib/model/SolarSystemModel.ts
@@ -4,13 +4,13 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
+import { getCanvasPixels, isOffScreen } from '../canvas.ts';
 import { Time } from '../epoch.ts';
 import { convertToEpoch, G, keplerianToCartesian } from '../physics.ts';
 import { ORBITAL_REGIMES } from '../regimes.ts';
 import { ModelState, Settings } from '../state.ts';
 import { CelestialBody, CelestialBodyType, Point2, Point3 } from '../types.ts';
 import { notNullish } from '../utils.ts';
-import { getCanvasPixels, isOffScreen } from './canvas.ts';
 import { CAMERA_INIT, SCALE_FACTOR, SUNLIGHT_COLOR } from './constants.ts';
 import { Firmament } from './Firmament.ts';
 import { FrameRateCounter } from './FrameRateCounter.ts';
@@ -138,16 +138,12 @@ export class SolarSystemModel {
     toRemove.dispose();
   }
 
-  setEpoch(settings: Settings) {
+  reset(settings: Settings, viewport = true) {
     this.time = 0;
-    Object.values(this.bodies).forEach(body => body.dispose());
-    this.bodies = this.createBodies(settings);
-  }
-
-  reset(settings: Settings) {
-    this.time = 0;
-    this.setupCamera();
-    this.controls.reset();
+    if (viewport) {
+      this.setupCamera();
+      this.controls.reset();
+    }
     Object.values(this.bodies).forEach(body => body.dispose());
     this.bodies = this.createBodies(settings);
   }

--- a/src/lib/model/canvas.ts
+++ b/src/lib/model/canvas.ts
@@ -1,6 +1,6 @@
 import { Point2 } from '../types.ts';
 
-export const LABEL_FONT_FAMILY = 'Electrolize, Arial';
+export const LABEL_FONT_FAMILY = 'Electrolize, sans-serif';
 
 export function isOffScreen([xPx, yPx]: Point2, [containerXpx, containerYpx]: Point2, marginPx = 0) {
   return xPx < -marginPx || xPx > containerXpx + marginPx || yPx < -marginPx || yPx > containerYpx + marginPx;

--- a/src/lib/model/canvas.ts
+++ b/src/lib/model/canvas.ts
@@ -11,6 +11,17 @@ export function getCanvasPixels(ctx: CanvasRenderingContext2D): Point2 {
   return [ctx.canvas.width / dpr, ctx.canvas.height / dpr];
 }
 
+export function isLabelFontAvailable(ctx: CanvasRenderingContext2D) {
+  const exampleString = 'An Example String';
+  ctx.save();
+  ctx.font = `12px ${LABEL_FONT_FAMILY}`;
+  const primary = ctx.measureText(exampleString);
+  ctx.font = '12px sans-serif';
+  const fallback = ctx.measureText(exampleString);
+  ctx.restore();
+  return primary.width !== fallback.width;
+}
+
 // TODO: corners behave weirdly with this implementation; may want 4 more types for the corners
 export function drawOffscreenIndicator(
   ctx: CanvasRenderingContext2D,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,7 +53,9 @@ export function celestialBodyTypeName(type: CelestialBodyType, plural = false): 
 
 export function celestialBodyTypeDescription(body: CelestialBody): string {
   const baseName = celestialBodyTypeName(body.type);
-  return body.type !== CelestialBodyType.MOON ? baseName : `${baseName} of ${body.elements.wrt}`;
+  // TODO: this is a hack; shouldn't assume IDs are human-readable. Works for now
+  const parentCapitalized = `${String(body.elements.wrt).charAt(0).toUpperCase()}${String(body.elements.wrt).slice(1)}`;
+  return body.type !== CelestialBodyType.MOON ? baseName : `${baseName} of ${parentCapitalized}`;
 }
 
 export function notNullish<TValue>(value: TValue | null | undefined): value is TValue {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@mantine/core/styles.css';
 import '@mantine/spotlight/styles.css';
+import '@mantine/dates/styles.css';
 import './index.css';
 import { App } from './App.tsx';
 

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Button, createTheme, Modal, Paper, Tooltip } from '@mantine/core';
+import { ActionIcon, Button, createTheme, Modal, Paper, Popover, Tooltip } from '@mantine/core';
 
 export const theme = createTheme({
   primaryColor: 'blue',
@@ -13,6 +13,7 @@ export const theme = createTheme({
       },
     }),
     Tooltip: Tooltip.extend({ defaultProps: { fz: 'xs', px: 6, py: 2, openDelay: 400 } }),
+    Popover: Popover.extend({ defaultProps: { transitionProps: { transition: 'fade', duration: 200 } } }),
     Paper: Paper.extend({ defaultProps: { bg: 'transparent', style: { backdropFilter: 'blur(4px)' } } }),
     Modal: Modal.extend({
       defaultProps: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,6 +910,13 @@
     react-textarea-autosize "8.5.5"
     type-fest "^4.27.0"
 
+"@mantine/dates@^7.15.3":
+  version "7.15.3"
+  resolved "https://registry.yarnpkg.com/@mantine/dates/-/dates-7.15.3.tgz#05c67e97370530c31f5faae50c4086f30977a381"
+  integrity sha512-lv71dcfA8qB43v03cRELC2/G7FQXfAgj0tSMImj2p2FL3PSWWF4WRvW6byiB+hszk4lgooSo7kppzkSMVUlsdA==
+  dependencies:
+    clsx "^2.1.1"
+
 "@mantine/hooks@^7.14.3":
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/@mantine/hooks/-/hooks-7.14.3.tgz#26bfbf7d851989be170caaae4189833131a3e28a"
@@ -3937,6 +3944,11 @@ date-time@^3.1.0:
   integrity sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==
   dependencies:
     time-zone "^1.0.0"
+
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
 debug@2.6.9:
   version "2.6.9"


### PR DESCRIPTION
- Add a date picker for any date between 1900 and 2200
- Fix an issue with label width being cached before primary font is loaded
- Update various UI elements to use the stylized font
- Add a lot more options to speed controls, e.g. 12 hours, 3 months