### PR TITLE
Add spacecraft to fact sheets

### DIFF
--- a/src/components/Controls/SelectOmnibox.tsx
+++ b/src/components/Controls/SelectOmnibox.tsx
@@ -8,7 +8,7 @@ import { ORBITAL_REGIMES, orbitalRegimeDisplayName } from '../../lib/regimes.ts'
 import { Settings, UpdateSettings } from '../../lib/state.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import { celestialBodyTypeDescription } from '../../lib/utils.ts';
-import { Thumbnail } from '../FactSheet/Thumbnail.tsx';
+import { CelestialBodyThumbnail } from '../FactSheet/CelestialBodyThumbnail.tsx';
 import { iconSize } from './constants.ts';
 import styles from './SelectOmnibox.module.css';
 
@@ -33,7 +33,7 @@ export function SelectOmnibox({ settings, updateSettings }: Props) {
             leftSection={
               // TODO: lazy load thumbnails for visible objects only
               <Box miw={24}>
-                <Thumbnail body={body} size={24} />
+                <CelestialBodyThumbnail body={body} size={24} />
               </Box>
             }
             rightSection={

--- a/src/components/FactSheet/BodyCard.module.css
+++ b/src/components/FactSheet/BodyCard.module.css
@@ -1,3 +1,6 @@
+.Card {
+  cursor: pointer;
+}
 .Card:hover {
   background-color: color-mix(in srgb, var(--mantine-color-gray-9), transparent 50%) !important;
 }

--- a/src/components/FactSheet/BodyCard.tsx
+++ b/src/components/FactSheet/BodyCard.tsx
@@ -17,7 +17,6 @@ export function BodyCard({ body, onClick, onHover }: Props) {
       className={styles.Card}
       withBorder
       p="xs"
-      style={{ cursor: 'pointer' }}
       onClick={onClick}
       onMouseEnter={onHover != null ? () => onHover(true) : undefined}
       onMouseLeave={onHover != null ? () => onHover(false) : undefined}

--- a/src/components/FactSheet/BodyCard.tsx
+++ b/src/components/FactSheet/BodyCard.tsx
@@ -2,8 +2,8 @@ import { Box, Paper, Text, Title } from '@mantine/core';
 import { useSummaryStream } from '../../hooks/useSummaryStream.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import styles from './BodyCard.module.css';
+import { CelestialBodyThumbnail } from './CelestialBodyThumbnail.tsx';
 import { LoadingCursor } from './LoadingCursor.tsx';
-import { Thumbnail } from './Thumbnail.tsx';
 
 type Props = {
   body: CelestialBody;
@@ -23,7 +23,7 @@ export function BodyCard({ body, onClick, onHover }: Props) {
       onMouseLeave={onHover != null ? () => onHover(false) : undefined}
     >
       <Box ml="xs" style={{ float: 'right' }}>
-        <Thumbnail body={body} size={100} />
+        <CelestialBodyThumbnail body={body} size={100} />
       </Box>
       <Title order={6}>{body.name}</Title>
       <Text mt={4} inherit c="dimmed" fz="xs">

--- a/src/components/FactSheet/CelestialBodyFactSheet.tsx
+++ b/src/components/FactSheet/CelestialBodyFactSheet.tsx
@@ -4,9 +4,11 @@ import { useDisplaySize } from '../../hooks/useDisplaySize.ts';
 import { useFactsStream } from '../../hooks/useFactsStream.ts';
 import { g } from '../../lib/bodies.ts';
 import { orbitalPeriod, surfaceGravity } from '../../lib/physics.ts';
+import { SPACECRAFT_BY_BODY_ID } from '../../lib/spacecraft.ts';
 import { UpdateSettings } from '../../lib/state.ts';
 import { CelestialBody, CelestialBodyType } from '../../lib/types.ts';
 import { celestialBodyTypeDescription, humanDistanceUnits, humanTimeUnits, pluralize } from '../../lib/utils.ts';
+import { CelestialBodyThumbnail } from './CelestialBodyThumbnail.tsx';
 import { FactGrid } from './FactGrid.tsx';
 import { FactSheetSummary } from './FactSheetSummary.tsx';
 import { FactSheetTitle } from './FactSheetTitle.tsx';
@@ -17,13 +19,14 @@ import { OrbitalRegimePill } from './OrbitalRegimePill.tsx';
 import { OtherBodies } from './OtherBodies.tsx';
 import { OtherRegimes } from './OtherRegimes.tsx';
 import { ParentBody } from './ParentBody.tsx';
-import { Thumbnail } from './Thumbnail.tsx';
+import { SpacecraftVisits } from './SpacecraftVisits.tsx';
 
 type Props = {
   body: CelestialBody;
   bodies: Array<CelestialBody>;
   updateSettings: UpdateSettings;
 };
+
 export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetComponent({
   body,
   bodies,
@@ -69,6 +72,7 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
   ];
   const factBullets = factsAsBullets(facts);
   const galleryAssets = body.assets?.gallery ?? [];
+  const spacecraftVisited = SPACECRAFT_BY_BODY_ID[body.id] ?? [];
 
   return (
     <Stack fz="xs" gap={2} h="100%" style={{ overflow: 'auto' }} flex={1}>
@@ -84,7 +88,7 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
         <Group gap={0} justify="space-between" align="flex-start" wrap="nowrap" w="100%">
           <FactSheetSummary obj={body} />
           <Box pt="md" pr="md" style={{ flexShrink: 0 }}>
-            <Thumbnail key={body.name} body={body} size={160} />
+            <CelestialBodyThumbnail key={body.name} body={body} size={160} />
           </Box>
         </Group>
       ) : (
@@ -99,7 +103,7 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
           </Stack>
           {!isXsDisplay && (
             <Box style={{ flexShrink: 1 }}>
-              <Thumbnail key={body.name} body={body} size={220} />
+              <CelestialBodyThumbnail key={body.name} body={body} size={220} />
             </Box>
           )}
         </Group>
@@ -117,6 +121,7 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
         {galleryAssets.length > 0 && <Gallery assets={galleryAssets} />}
         <MajorSatellites body={body} bodies={bodies} updateSettings={updateSettings} />
         <ParentBody body={body} bodies={bodies} updateSettings={updateSettings} />
+        {spacecraftVisited.length > 0 && <SpacecraftVisits spacecraft={spacecraftVisited} body={body} />}
         <OtherBodies body={body} bodies={bodies} updateSettings={updateSettings} />
         {body.type === CelestialBodyType.STAR && (
           <OtherRegimes updateSettings={updateSettings} title="Orbital Regimes" />

--- a/src/components/FactSheet/CelestialBodyFactSheet.tsx
+++ b/src/components/FactSheet/CelestialBodyFactSheet.tsx
@@ -117,7 +117,7 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
         </Box>
       </Stack>
 
-      <Box style={{ justifySelf: 'flex-end' }}>
+      <Box pt="md" style={{ justifySelf: 'flex-end' }}>
         {galleryAssets.length > 0 && <Gallery assets={galleryAssets} />}
         <MajorSatellites body={body} bodies={bodies} updateSettings={updateSettings} />
         <ParentBody body={body} bodies={bodies} updateSettings={updateSettings} />

--- a/src/components/FactSheet/CelestialBodyThumbnail.tsx
+++ b/src/components/FactSheet/CelestialBodyThumbnail.tsx
@@ -1,0 +1,12 @@
+import { CelestialBody } from '../../lib/types.ts';
+import { Thumbnail } from './Thumbnail.tsx';
+
+type Props = {
+  body: CelestialBody;
+  size: number;
+};
+export function CelestialBodyThumbnail({ body, size }: Props) {
+  const { name, type } = body;
+  const search = `${name} ${type}`;
+  return <Thumbnail thumbnail={body.assets?.thumbnail} search={search} size={size} />;
+}

--- a/src/components/FactSheet/FactSheetSummary.tsx
+++ b/src/components/FactSheet/FactSheetSummary.tsx
@@ -1,10 +1,11 @@
 import { Box, Text } from '@mantine/core';
 import { useSummaryStream } from '../../hooks/useSummaryStream.ts';
+import { Spacecraft } from '../../lib/spacecraft.ts';
 import { CelestialBody, OrbitalRegime } from '../../lib/types.ts';
 import { LoadingCursor } from './LoadingCursor.tsx';
 
 type Props = {
-  obj: CelestialBody | OrbitalRegime;
+  obj: CelestialBody | OrbitalRegime | Spacecraft;
 };
 export function FactSheetSummary({ obj }: Props) {
   const { data: summary, isLoading } = useSummaryStream(obj);

--- a/src/components/FactSheet/Gallery.tsx
+++ b/src/components/FactSheet/Gallery.tsx
@@ -35,7 +35,7 @@ export function Gallery({ assets }: Props) {
     )
   );
   return (
-    <Stack p="md" pt="xl" gap="xs">
+    <Stack p="md" pt="lg" gap="xs">
       <Title order={5}>Gallery</Title>
       {isXsDisplay || assets.length > 3 ? (
         <Carousel

--- a/src/components/FactSheet/MajorSatellites.tsx
+++ b/src/components/FactSheet/MajorSatellites.tsx
@@ -31,7 +31,7 @@ export function MajorSatellites({ body, bodies, updateSettings }: Props) {
   const satelliteTypeDisplayName =
     satelliteTypes.size !== 1 ? 'Satellites' : celestialBodyTypeName(satelliteTypes.values().next().value!, true);
   return (
-    <Stack gap="xs" p="md" pt="xl">
+    <Stack gap="xs" p="md" pt="lg">
       <Title order={5}>Major {satelliteTypeDisplayName}</Title>
       {satellites.map((satellite, i) => (
         <BodyCard

--- a/src/components/FactSheet/OtherBodies.tsx
+++ b/src/components/FactSheet/OtherBodies.tsx
@@ -25,7 +25,7 @@ export function OtherBodies({ body, bodies, updateSettings }: Props) {
 
   const thumbnailSize = 14;
   return otherBodies.length > 0 ? (
-    <Stack gap="xs" p="md">
+    <Stack gap="xs" p="md" pt="lg">
       <Title order={5}>Other {celestialBodyTypeName(body.type, true)}</Title>
       <Group gap={8}>
         {otherBodies.map((relatedBody, i) => (

--- a/src/components/FactSheet/OtherBodies.tsx
+++ b/src/components/FactSheet/OtherBodies.tsx
@@ -3,8 +3,8 @@ import { useMemo } from 'react';
 import { Settings } from '../../lib/state.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
+import { CelestialBodyThumbnail } from './CelestialBodyThumbnail.tsx';
 import styles from './RelatedBodies.module.css';
-import { Thumbnail } from './Thumbnail.tsx';
 
 const N_RELATED = 6;
 
@@ -39,7 +39,7 @@ export function OtherBodies({ body, bodies, updateSettings }: Props) {
           >
             <Group gap={8} align="center" wrap="nowrap">
               <Box w={thumbnailSize}>
-                <Thumbnail body={relatedBody} size={thumbnailSize} />
+                <CelestialBodyThumbnail body={relatedBody} size={thumbnailSize} />
               </Box>
               {relatedBody.shortName ?? relatedBody.name}
             </Group>

--- a/src/components/FactSheet/OtherRegimes.tsx
+++ b/src/components/FactSheet/OtherRegimes.tsx
@@ -17,7 +17,7 @@ export function OtherRegimes({ regime, updateSettings, title = 'Other Orbital Re
   );
 
   return (
-    <Stack gap="xs" p="md">
+    <Stack gap="xs" p="md" pt="lg">
       <Title order={5}>{title}</Title>
       <Group gap={8}>
         {otherRegimes.map((otherRegime, i) => (

--- a/src/components/FactSheet/ParentBody.tsx
+++ b/src/components/FactSheet/ParentBody.tsx
@@ -16,7 +16,7 @@ export function ParentBody({ body, bodies, updateSettings }: Props) {
     [JSON.stringify(body), JSON.stringify(bodies)]
   );
   return parentBody != null ? (
-    <Stack gap="xs" p="md" pt="xl">
+    <Stack gap="xs" p="md" pt="lg">
       <Title order={5}>Parent {celestialBodyTypeName(parentBody.type)}</Title>
       <BodyCard
         body={parentBody}

--- a/src/components/FactSheet/SpacecraftCard.tsx
+++ b/src/components/FactSheet/SpacecraftCard.tsx
@@ -1,0 +1,52 @@
+import { Box, Group, Paper, Text, Title, UnstyledButton } from '@mantine/core';
+import { useSummaryStream } from '../../hooks/useSummaryStream.ts';
+import { Spacecraft, SpacecraftVisitType } from '../../lib/spacecraft.ts';
+import { CelestialBody } from '../../lib/types.ts';
+import styles from './BodyCard.module.css';
+import { LoadingCursor } from './LoadingCursor.tsx';
+import { SpacecraftOrganizationPill } from './SpacecraftOrganizationPill.tsx';
+import { SpacecraftStatusPill } from './SpacecraftStatusPill.tsx';
+import { Thumbnail } from './Thumbnail.tsx';
+
+type Props = {
+  spacecraft: Spacecraft;
+  body: CelestialBody;
+};
+export function SpacecraftCard({ spacecraft, body }: Props) {
+  const { data: summary, isLoading } = useSummaryStream(spacecraft);
+  const visitInfo = spacecraft.visited.find(({ id }) => id === body.id)!;
+  const visitVerb =
+    visitInfo.type === SpacecraftVisitType.ROVER || visitInfo.type === SpacecraftVisitType.LANDER
+      ? 'landed'
+      : visitInfo.type === SpacecraftVisitType.ORBITER
+        ? 'entered orbit'
+        : visitInfo.type === SpacecraftVisitType.HELICOPTER
+          ? 'started flying'
+          : 'visited';
+  return (
+    <UnstyledButton component="a" href={spacecraft.wiki} target="_blank">
+      <Paper className={styles.Card} withBorder p="xs" style={{ overflow: 'auto' }}>
+        {spacecraft.thumbnail != null && (
+          <Box ml="xs" style={{ float: 'right' }}>
+            <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
+          </Box>
+        )}
+        <Group gap="xs" align="center">
+          <Title order={6}>{spacecraft.name}</Title>
+          <Text c="dimmed" fz="sm" fs="italic">
+            {visitInfo.type}
+          </Text>
+          <SpacecraftOrganizationPill organization={spacecraft.organization} />
+          <SpacecraftStatusPill status={spacecraft.status} />
+        </Group>
+        <Text mt={4} fz="xs" fs="italic">
+          Launched in {spacecraft.start.getFullYear()}, {visitVerb} in {visitInfo.start.getFullYear()}
+        </Text>
+        <Text mt={4} c="dimmed" fz="xs">
+          {summary}
+          {isLoading && <LoadingCursor />}
+        </Text>
+      </Paper>
+    </UnstyledButton>
+  );
+}

--- a/src/components/FactSheet/SpacecraftOrganizationPill.tsx
+++ b/src/components/FactSheet/SpacecraftOrganizationPill.tsx
@@ -1,0 +1,20 @@
+import { Box, Group, Pill } from '@mantine/core';
+import { SPACECRAFT_ORGANIZATIONS, SpacecraftOrganization } from '../../lib/spacecraft.ts';
+import { Thumbnail } from './Thumbnail.tsx';
+
+type Props = {
+  organization: SpacecraftOrganization;
+};
+export function SpacecraftOrganizationPill({ organization }: Props) {
+  const details = SPACECRAFT_ORGANIZATIONS[organization];
+  return (
+    <Pill>
+      <Group gap={8} wrap="nowrap">
+        <Box w={14}>
+          <Thumbnail size={14} thumbnail={details.thumbnail} />
+        </Box>
+        {details.shortName}
+      </Group>
+    </Pill>
+  );
+}

--- a/src/components/FactSheet/SpacecraftStatusPill.module.css
+++ b/src/components/FactSheet/SpacecraftStatusPill.module.css
@@ -1,0 +1,14 @@
+@keyframes blink {
+  0%,
+  59% {
+    opacity: 1;
+  }
+  60%,
+  100% {
+    opacity: 0.5;
+  }
+}
+
+.StatusIcon {
+  animation: blink 2s infinite;
+}

--- a/src/components/FactSheet/SpacecraftStatusPill.tsx
+++ b/src/components/FactSheet/SpacecraftStatusPill.tsx
@@ -9,12 +9,12 @@ type Props = {
 export function SpacecraftStatusPill({ status: { status, details } }: Props) {
   const color =
     status === SpacecraftStatus.OPERATIONAL
-      ? 'green'
+      ? 'var(--mantine-color-green-7)'
       : status === SpacecraftStatus.DECOMMISSIONED
-        ? 'orange'
+        ? 'var(--mantine-color-gray-7)' // TODO: better color?
         : status === SpacecraftStatus.CRASHED
-          ? 'red'
-          : 'gray';
+          ? 'var(--mantine-color-red-7)'
+          : 'var(--mantine-color-gray-7)';
   const PillComponent = (
     <Pill>
       <Group gap={8} wrap="nowrap">

--- a/src/components/FactSheet/SpacecraftStatusPill.tsx
+++ b/src/components/FactSheet/SpacecraftStatusPill.tsx
@@ -8,7 +8,13 @@ type Props = {
 };
 export function SpacecraftStatusPill({ status: { status, details } }: Props) {
   const color =
-    status === SpacecraftStatus.OPERATIONAL ? 'green' : status === SpacecraftStatus.CRASHED ? 'orange' : 'gray';
+    status === SpacecraftStatus.OPERATIONAL
+      ? 'green'
+      : status === SpacecraftStatus.DECOMMISSIONED
+        ? 'orange'
+        : status === SpacecraftStatus.CRASHED
+          ? 'red'
+          : 'gray';
   const PillComponent = (
     <Pill>
       <Group gap={8} wrap="nowrap">

--- a/src/components/FactSheet/SpacecraftStatusPill.tsx
+++ b/src/components/FactSheet/SpacecraftStatusPill.tsx
@@ -1,0 +1,25 @@
+import { Group, Pill, Tooltip } from '@mantine/core';
+import { IconCircleFilled } from '@tabler/icons-react';
+import { Spacecraft, SpacecraftStatus } from '../../lib/spacecraft.ts';
+import styles from './SpacecraftStatusPill.module.css';
+
+type Props = {
+  status: Spacecraft['status'];
+};
+export function SpacecraftStatusPill({ status: { status, details } }: Props) {
+  const color =
+    status === SpacecraftStatus.OPERATIONAL ? 'green' : status === SpacecraftStatus.CRASHED ? 'orange' : 'gray';
+  const PillComponent = (
+    <Pill>
+      <Group gap={8} wrap="nowrap">
+        <IconCircleFilled
+          className={status === SpacecraftStatus.OPERATIONAL ? styles.StatusIcon : undefined}
+          size={6}
+          color={color}
+        />
+        {status}
+      </Group>
+    </Pill>
+  );
+  return details != null ? <Tooltip label={details}>{PillComponent}</Tooltip> : PillComponent;
+}

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -1,12 +1,7 @@
-import { Box, Group, Paper, Stack, Text, Title, UnstyledButton } from '@mantine/core';
-import { useSummaryStream } from '../../hooks/useSummaryStream.ts';
-import { Spacecraft, SpacecraftVisitType } from '../../lib/spacecraft.ts';
+import { Stack, Title } from '@mantine/core';
+import { Spacecraft } from '../../lib/spacecraft.ts';
 import { CelestialBody } from '../../lib/types.ts';
-import styles from './BodyCard.module.css';
-import { LoadingCursor } from './LoadingCursor.tsx';
-import { SpacecraftOrganizationPill } from './SpacecraftOrganizationPill.tsx';
-import { SpacecraftStatusPill } from './SpacecraftStatusPill.tsx';
-import { Thumbnail } from './Thumbnail.tsx';
+import { SpacecraftCard } from './SpacecraftCard.tsx';
 
 type Props = {
   spacecraft: Array<Spacecraft>;
@@ -14,54 +9,11 @@ type Props = {
 };
 export function SpacecraftVisits({ spacecraft, body }: Props) {
   return (
-    <Stack gap="xs" p="md" pt="xl">
+    <Stack gap="xs" p="md" pt="lg">
       <Title order={5}>Spacecraft Visits</Title>
       {spacecraft.map((s, i) => (
         <SpacecraftCard key={`${s.name}-${i}`} spacecraft={s} body={body} />
       ))}
     </Stack>
-  );
-}
-
-type SpacecraftCardProps = {
-  spacecraft: Spacecraft;
-  body: CelestialBody;
-};
-function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
-  const { data: summary, isLoading } = useSummaryStream(spacecraft);
-  const visitInfo = spacecraft.visited.find(({ id }) => id === body.id)!;
-  const visitVerb =
-    visitInfo.type === SpacecraftVisitType.ROVER || visitInfo.type === SpacecraftVisitType.LANDER
-      ? 'landed'
-      : visitInfo.type === SpacecraftVisitType.ORBITER
-        ? 'entered orbit'
-        : visitInfo.type === SpacecraftVisitType.HELICOPTER
-          ? 'started flying'
-          : 'visited';
-  return (
-    <UnstyledButton component="a" href={spacecraft.wiki} target="_blank">
-      <Paper className={styles.Card} withBorder p="xs" style={{ overflow: 'auto' }}>
-        {spacecraft.thumbnail != null && (
-          <Box ml="xs" style={{ float: 'right' }}>
-            <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
-          </Box>
-        )}
-        <Group gap="xs" align="center">
-          <Title order={6}>{spacecraft.name}</Title>
-          <Text c="dimmed" fz="sm" fs="italic">
-            {visitInfo.type}
-          </Text>
-          <SpacecraftOrganizationPill organization={spacecraft.organization} />
-          <SpacecraftStatusPill status={spacecraft.status} />
-        </Group>
-        <Text mt={4} fz="xs" fs="italic">
-          Launched in {spacecraft.start.getFullYear()}, {visitVerb} in {visitInfo.start.getFullYear()}
-        </Text>
-        <Text mt={4} c="dimmed" fz="xs">
-          {summary}
-          {isLoading && <LoadingCursor />}
-        </Text>
-      </Paper>
-    </UnstyledButton>
   );
 }

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -41,9 +41,11 @@ function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
               Launched in {spacecraft.start.getFullYear()}, visited in {visitInfo.start.getFullYear()}
             </Text>
           </Stack>
-          <Box style={{ flexShrink: 0 }}>
-            <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
-          </Box>
+          {spacecraft.thumbnail != null && (
+            <Box style={{ flexShrink: 0 }}>
+              <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
+            </Box>
+          )}
         </Group>
       </Paper>
     </UnstyledButton>

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -1,0 +1,40 @@
+import { Box, Group, Paper, Stack, Text, Title } from '@mantine/core';
+import { Spacecraft } from '../../lib/spacecraft.ts';
+import { CelestialBody } from '../../lib/types.ts';
+import { Thumbnail } from './Thumbnail.tsx';
+
+type Props = {
+  spacecraft: Array<Spacecraft>;
+  body: CelestialBody;
+};
+export function SpacecraftVisits({ spacecraft, body }: Props) {
+  return (
+    <Stack gap="xs" p="md" pt="xl">
+      <Title order={5}>Spacecraft Visits</Title>
+      {spacecraft.map((s, i) => (
+        <SpacecraftCard key={`${s.name}-${i}`} spacecraft={s} body={body} />
+      ))}
+    </Stack>
+  );
+}
+
+type SpacecraftCardProps = {
+  spacecraft: Spacecraft;
+  body: CelestialBody;
+};
+function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
+  const visitInfo = spacecraft.visited.find(({ id }) => id === body.id)!;
+  return (
+    <Paper withBorder p="xs">
+      <Group gap={8} align="baseline">
+        <Title order={6}>{spacecraft.name}</Title>
+        <Text c="dimmed" fz="xs">
+          Launched in {spacecraft.start.getFullYear()}, visited in {visitInfo.start.getFullYear()}
+        </Text>
+      </Group>
+      <Box ml="xs" style={{ float: 'right' }}>
+        <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
+      </Box>
+    </Paper>
+  );
+}

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -4,6 +4,7 @@ import { Spacecraft, SPACECRAFT_ORGANIZATIONS, SpacecraftOrganization } from '..
 import { CelestialBody } from '../../lib/types.ts';
 import styles from './BodyCard.module.css';
 import { LoadingCursor } from './LoadingCursor.tsx';
+import { SpacecraftStatusPill } from './SpacecraftStatusPill.tsx';
 import { Thumbnail } from './Thumbnail.tsx';
 
 type Props = {
@@ -30,7 +31,7 @@ function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
   const visitInfo = spacecraft.visited.find(({ id }) => id === body.id)!;
   return (
     <UnstyledButton component="a" href={spacecraft.wiki} target="_blank">
-      <Paper className={styles.Card} withBorder p="xs">
+      <Paper className={styles.Card} withBorder p="xs" style={{ overflow: 'auto' }}>
         {spacecraft.thumbnail != null && (
           <Box ml="xs" style={{ float: 'right' }}>
             <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
@@ -38,10 +39,11 @@ function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
         )}
         <Group gap="xs" align="center">
           <Title order={6}>{spacecraft.name}</Title>
-          <SpacecraftOrganizationPill organization={spacecraft.organization} />
           <Text c="dimmed" fz="sm" fs="italic">
             {visitInfo.type}
           </Text>
+          <SpacecraftOrganizationPill organization={spacecraft.organization} />
+          <SpacecraftStatusPill status={spacecraft.status} />
         </Group>
         <Text mt={4} fz="xs" fs="italic">
           Launched in {spacecraft.start.getFullYear()}, visited in {visitInfo.start.getFullYear()}
@@ -63,11 +65,9 @@ function SpacecraftOrganizationPill({ organization }: SpacecraftOrganizationPill
   return (
     <Box style={{ flexShrink: 0 }}>
       <Pill>
-        <Group w="100%" gap={8} wrap="nowrap">
+        <Group gap={8} wrap="nowrap">
           <Thumbnail size={14} thumbnail={details.thumbnail} />
-          <Text inherit style={{ display: 'flex', flexShrink: 0 }}>
-            {details.shortName}
-          </Text>
+          {details.shortName}
         </Group>
       </Pill>
     </Box>

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -1,7 +1,9 @@
 import { Box, Group, Paper, Pill, Stack, Text, Title, UnstyledButton } from '@mantine/core';
-import { Spacecraft, SpacecraftOrganization } from '../../lib/spacecraft.ts';
+import { useSummaryStream } from '../../hooks/useSummaryStream.ts';
+import { Spacecraft, SPACECRAFT_ORGANIZATIONS, SpacecraftOrganization } from '../../lib/spacecraft.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import styles from './BodyCard.module.css';
+import { LoadingCursor } from './LoadingCursor.tsx';
 import { Thumbnail } from './Thumbnail.tsx';
 
 type Props = {
@@ -24,29 +26,30 @@ type SpacecraftCardProps = {
   body: CelestialBody;
 };
 function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
+  const { data: summary, isLoading } = useSummaryStream(spacecraft);
   const visitInfo = spacecraft.visited.find(({ id }) => id === body.id)!;
   return (
     <UnstyledButton component="a" href={spacecraft.wiki} target="_blank">
       <Paper className={styles.Card} withBorder p="xs">
-        <Group gap="xs" justify="space-between" align="flex-start">
-          <Stack gap={4} align="flex-start">
-            <Group gap="xs" align="baseline">
-              <Title order={6}>{spacecraft.name}</Title>
-              <SpacecraftOrganizationPill organization={spacecraft.organization} />
-              <Text c="dimmed" fz="sm" fs="italic">
-                {visitInfo.type}
-              </Text>
-            </Group>
-            <Text c="dimmed" fz="xs">
-              Launched in {spacecraft.start.getFullYear()}, visited in {visitInfo.start.getFullYear()}
-            </Text>
-          </Stack>
-          {spacecraft.thumbnail != null && (
-            <Box style={{ flexShrink: 0 }}>
-              <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
-            </Box>
-          )}
+        {spacecraft.thumbnail != null && (
+          <Box ml="xs" style={{ float: 'right' }}>
+            <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
+          </Box>
+        )}
+        <Group gap="xs" align="center">
+          <Title order={6}>{spacecraft.name}</Title>
+          <SpacecraftOrganizationPill organization={spacecraft.organization} />
+          <Text c="dimmed" fz="sm" fs="italic">
+            {visitInfo.type}
+          </Text>
         </Group>
+        <Text mt={4} fz="xs" fs="italic">
+          Launched in {spacecraft.start.getFullYear()}, visited in {visitInfo.start.getFullYear()}
+        </Text>
+        <Text mt={4} c="dimmed" fz="xs">
+          {summary}
+          {isLoading && <LoadingCursor />}
+        </Text>
       </Paper>
     </UnstyledButton>
   );
@@ -56,13 +59,14 @@ type SpacecraftOrganizationPillProps = {
   organization: SpacecraftOrganization;
 };
 function SpacecraftOrganizationPill({ organization }: SpacecraftOrganizationPillProps) {
+  const details = SPACECRAFT_ORGANIZATIONS[organization];
   return (
     <Box style={{ flexShrink: 0 }}>
       <Pill>
         <Group w="100%" gap={8} wrap="nowrap">
-          <Thumbnail size={14} thumbnail={organization.thumbnail} />
+          <Thumbnail size={14} thumbnail={details.thumbnail} />
           <Text inherit style={{ display: 'flex', flexShrink: 0 }}>
-            {organization.shortName}
+            {details.shortName}
           </Text>
         </Group>
       </Pill>

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -60,7 +60,7 @@ function SpacecraftOrganizationPill({ organization }: SpacecraftOrganizationPill
         <Group w="100%" gap={8} wrap="nowrap">
           <Thumbnail size={14} thumbnail={organization.thumbnail} />
           <Text inherit style={{ display: 'flex', flexShrink: 0 }}>
-            {organization.name}
+            {organization.shortName}
           </Text>
         </Group>
       </Pill>

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -1,14 +1,10 @@
-import { Box, Group, Paper, Pill, Stack, Text, Title, UnstyledButton } from '@mantine/core';
+import { Box, Group, Paper, Stack, Text, Title, UnstyledButton } from '@mantine/core';
 import { useSummaryStream } from '../../hooks/useSummaryStream.ts';
-import {
-  Spacecraft,
-  SPACECRAFT_ORGANIZATIONS,
-  SpacecraftOrganization,
-  SpacecraftVisitType,
-} from '../../lib/spacecraft.ts';
+import { Spacecraft, SpacecraftVisitType } from '../../lib/spacecraft.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import styles from './BodyCard.module.css';
 import { LoadingCursor } from './LoadingCursor.tsx';
+import { SpacecraftOrganizationPill } from './SpacecraftOrganizationPill.tsx';
 import { SpacecraftStatusPill } from './SpacecraftStatusPill.tsx';
 import { Thumbnail } from './Thumbnail.tsx';
 
@@ -67,22 +63,5 @@ function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
         </Text>
       </Paper>
     </UnstyledButton>
-  );
-}
-
-type SpacecraftOrganizationPillProps = {
-  organization: SpacecraftOrganization;
-};
-function SpacecraftOrganizationPill({ organization }: SpacecraftOrganizationPillProps) {
-  const details = SPACECRAFT_ORGANIZATIONS[organization];
-  return (
-    <Pill>
-      <Group gap={8} wrap="nowrap">
-        <Box w={14}>
-          <Thumbnail size={14} thumbnail={details.thumbnail} />
-        </Box>
-        {details.shortName}
-      </Group>
-    </Pill>
   );
 }

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -1,6 +1,11 @@
 import { Box, Group, Paper, Pill, Stack, Text, Title, UnstyledButton } from '@mantine/core';
 import { useSummaryStream } from '../../hooks/useSummaryStream.ts';
-import { Spacecraft, SPACECRAFT_ORGANIZATIONS, SpacecraftOrganization } from '../../lib/spacecraft.ts';
+import {
+  Spacecraft,
+  SPACECRAFT_ORGANIZATIONS,
+  SpacecraftOrganization,
+  SpacecraftVisitType,
+} from '../../lib/spacecraft.ts';
 import { CelestialBody } from '../../lib/types.ts';
 import styles from './BodyCard.module.css';
 import { LoadingCursor } from './LoadingCursor.tsx';
@@ -29,6 +34,14 @@ type SpacecraftCardProps = {
 function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
   const { data: summary, isLoading } = useSummaryStream(spacecraft);
   const visitInfo = spacecraft.visited.find(({ id }) => id === body.id)!;
+  const visitVerb =
+    visitInfo.type === SpacecraftVisitType.ROVER || visitInfo.type === SpacecraftVisitType.LANDER
+      ? 'landed'
+      : visitInfo.type === SpacecraftVisitType.ORBITER
+        ? 'entered orbit'
+        : visitInfo.type === SpacecraftVisitType.HELICOPTER
+          ? 'started flying'
+          : 'visited';
   return (
     <UnstyledButton component="a" href={spacecraft.wiki} target="_blank">
       <Paper className={styles.Card} withBorder p="xs" style={{ overflow: 'auto' }}>
@@ -46,7 +59,7 @@ function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
           <SpacecraftStatusPill status={spacecraft.status} />
         </Group>
         <Text mt={4} fz="xs" fs="italic">
-          Launched in {spacecraft.start.getFullYear()}, visited in {visitInfo.start.getFullYear()}
+          Launched in {spacecraft.start.getFullYear()}, {visitVerb} in {visitInfo.start.getFullYear()}
         </Text>
         <Text mt={4} c="dimmed" fz="xs">
           {summary}
@@ -63,13 +76,13 @@ type SpacecraftOrganizationPillProps = {
 function SpacecraftOrganizationPill({ organization }: SpacecraftOrganizationPillProps) {
   const details = SPACECRAFT_ORGANIZATIONS[organization];
   return (
-    <Box style={{ flexShrink: 0 }}>
-      <Pill>
-        <Group gap={8} wrap="nowrap">
+    <Pill>
+      <Group gap={8} wrap="nowrap">
+        <Box w={14}>
           <Thumbnail size={14} thumbnail={details.thumbnail} />
-          {details.shortName}
-        </Group>
-      </Pill>
-    </Box>
+        </Box>
+        {details.shortName}
+      </Group>
+    </Pill>
   );
 }

--- a/src/components/FactSheet/SpacecraftVisits.tsx
+++ b/src/components/FactSheet/SpacecraftVisits.tsx
@@ -1,6 +1,7 @@
-import { Box, Group, Paper, Stack, Text, Title } from '@mantine/core';
-import { Spacecraft } from '../../lib/spacecraft.ts';
+import { Box, Group, Paper, Pill, Stack, Text, Title, UnstyledButton } from '@mantine/core';
+import { Spacecraft, SpacecraftOrganization } from '../../lib/spacecraft.ts';
 import { CelestialBody } from '../../lib/types.ts';
+import styles from './BodyCard.module.css';
 import { Thumbnail } from './Thumbnail.tsx';
 
 type Props = {
@@ -25,16 +26,44 @@ type SpacecraftCardProps = {
 function SpacecraftCard({ spacecraft, body }: SpacecraftCardProps) {
   const visitInfo = spacecraft.visited.find(({ id }) => id === body.id)!;
   return (
-    <Paper withBorder p="xs">
-      <Group gap={8} align="baseline">
-        <Title order={6}>{spacecraft.name}</Title>
-        <Text c="dimmed" fz="xs">
-          Launched in {spacecraft.start.getFullYear()}, visited in {visitInfo.start.getFullYear()}
-        </Text>
-      </Group>
-      <Box ml="xs" style={{ float: 'right' }}>
-        <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
-      </Box>
-    </Paper>
+    <UnstyledButton component="a" href={spacecraft.wiki} target="_blank">
+      <Paper className={styles.Card} withBorder p="xs">
+        <Group gap="xs" justify="space-between" align="flex-start">
+          <Stack gap={4} align="flex-start">
+            <Group gap="xs" align="baseline">
+              <Title order={6}>{spacecraft.name}</Title>
+              <SpacecraftOrganizationPill organization={spacecraft.organization} />
+              <Text c="dimmed" fz="sm" fs="italic">
+                {visitInfo.type}
+              </Text>
+            </Group>
+            <Text c="dimmed" fz="xs">
+              Launched in {spacecraft.start.getFullYear()}, visited in {visitInfo.start.getFullYear()}
+            </Text>
+          </Stack>
+          <Box style={{ flexShrink: 0 }}>
+            <Thumbnail thumbnail={spacecraft.thumbnail} size={100} />
+          </Box>
+        </Group>
+      </Paper>
+    </UnstyledButton>
+  );
+}
+
+type SpacecraftOrganizationPillProps = {
+  organization: SpacecraftOrganization;
+};
+function SpacecraftOrganizationPill({ organization }: SpacecraftOrganizationPillProps) {
+  return (
+    <Box style={{ flexShrink: 0 }}>
+      <Pill>
+        <Group w="100%" gap={8} wrap="nowrap">
+          <Thumbnail size={14} thumbnail={organization.thumbnail} />
+          <Text inherit style={{ display: 'flex', flexShrink: 0 }}>
+            {organization.name}
+          </Text>
+        </Group>
+      </Pill>
+    </Box>
   );
 }

--- a/src/components/FactSheet/Thumbnail.tsx
+++ b/src/components/FactSheet/Thumbnail.tsx
@@ -1,19 +1,15 @@
 import { Image } from '@mantine/core';
 import { useState } from 'react';
 import { asCdnUrl } from '../../lib/images.ts';
-import { CelestialBody } from '../../lib/types.ts';
 
 type Props = {
-  body: CelestialBody;
+  thumbnail?: string;
+  search?: string; // used to search if thumbnail is absent
   size: number;
 };
-export function Thumbnail({ body, size }: Props) {
-  const { name, type } = body;
+export function Thumbnail({ thumbnail, search = '', size }: Props) {
   const [isValid, setIsValid] = useState(false);
-  const url =
-    body.assets?.thumbnail != null
-      ? asCdnUrl(body.assets.thumbnail)
-      : `/api/thumbnail?${new URLSearchParams({ search: `${name} ${type}` })}`;
+  const url = thumbnail != null ? asCdnUrl(thumbnail) : `/api/thumbnail?${new URLSearchParams({ search })}`;
   const validStyle = isValid ? {} : { display: 'none' };
   return (
     <Image

--- a/src/hooks/useSummaryStream.ts
+++ b/src/hooks/useSummaryStream.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import { orbitalRegimeDisplayName } from '../lib/regimes.ts';
+import { isSpacecraft, Spacecraft, SPACECRAFT_ORGANIZATIONS } from '../lib/spacecraft.ts';
 import {
   CelestialBody,
   CelestialBodyType,
@@ -10,7 +11,7 @@ import {
 } from '../lib/types.ts';
 import { celestialBodyTypeName } from '../lib/utils.ts';
 
-export function useSummaryStream(obj: CelestialBody | OrbitalRegime) {
+export function useSummaryStream(obj: CelestialBody | OrbitalRegime | Spacecraft) {
   const [isStreaming, setIsStreaming] = useState(false);
   const search = useMemo(() => getSearch(obj), [JSON.stringify(obj)]);
 
@@ -54,11 +55,14 @@ export function useSummaryStream(obj: CelestialBody | OrbitalRegime) {
   return { ...query, isLoading: isStreaming };
 }
 
-function getSearch(obj: CelestialBody | OrbitalRegime) {
+function getSearch(obj: CelestialBody | OrbitalRegime | Spacecraft) {
   if (isOrbitalRegime(obj)) {
     // provide the full set to anchor that e.g. the 'Outer System' is distinct from the 'Kuiper Belt'
     const orbitalRegimes = Object.values(HeliocentricOrbitalRegime).map(orbitalRegimeDisplayName).join(', ');
     return `the heliocentric orbital regime '${orbitalRegimeDisplayName(obj.id)}' (of the set with ${orbitalRegimes})`;
+  }
+  if (isSpacecraft(obj)) {
+    return `the ${SPACECRAFT_ORGANIZATIONS[obj.organization].shortName} spacecraft ${obj.name}`;
   }
   switch (obj.type) {
     case CelestialBodyType.MOON:

--- a/src/lib/bodies.ts
+++ b/src/lib/bodies.ts
@@ -1342,6 +1342,7 @@ export const CALLISTO = celestialBodyWithDefaults({
 });
 
 // TODO: there are more moons
+// TODO: at the very least, Amalthea?
 export const JUPITER_SYSTEM = [JUPITER, IO, EUROPA, GANYMEDE, CALLISTO];
 
 export const SATURN = celestialBodyWithDefaults({

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -46,17 +46,20 @@ export const SPACECRAFT_ORGANIZATIONS: Record<SpacecraftOrganization, Spacecraft
   [SpacecraftOrganization.JAXA]: JAXA,
 };
 
+// TODO: mixing concerns here -- some are identity-related, others are visit-related
 export enum SpacecraftVisitType {
   FLYBY = 'Flyby',
-  ORBIT = 'Orbit',
-  LANDING = 'Landing',
-  ROVER = 'Rover',
   GRAVITY_ASSIST = 'Gravity Assist',
+  ORBITER = 'Orbiter',
+  LANDER = 'Lander',
+  ROVER = 'Rover',
+  HELICOPTER = 'Helicopter',
 }
 
 export enum SpacecraftStatus {
   OPERATIONAL = 'Operational',
   DEFUNCT = 'Defunct',
+  DECOMMISSIONED = 'Decommissioned',
   CRASHED = 'Crashed',
 }
 
@@ -180,7 +183,7 @@ export const CASSINI: Spacecraft = {
   power: 885,
   start: new Date('1997-10-15T08:43:00Z'),
   status: {
-    status: SpacecraftStatus.CRASHED,
+    status: SpacecraftStatus.DECOMMISSIONED,
     details: "Intentionally flown into Saturn's atmosphere on September 15th, 2017",
   },
   thumbnail: 'cassini-huygens.gif',
@@ -194,7 +197,7 @@ export const CASSINI: Spacecraft = {
     // primary mission
     {
       id: Bodies.SATURN.id,
-      type: SpacecraftVisitType.ORBIT,
+      type: SpacecraftVisitType.ORBITER,
       start: new Date('2004-05-18T12:00:00Z'),
       end: new Date('2017-09-15T11:55:00Z'),
     },
@@ -219,7 +222,7 @@ export const HUYGENS: Spacecraft = {
   status: { status: SpacecraftStatus.DEFUNCT },
   thumbnail: 'huygens-thumb.jpg',
   wiki: 'https://en.wikipedia.org/wiki/Huygens_(spacecraft)',
-  visited: [{ id: Bodies.TITAN.id, type: SpacecraftVisitType.LANDING, start: new Date('2005-01-14T12:43:00Z') }],
+  visited: [{ id: Bodies.TITAN.id, type: SpacecraftVisitType.LANDER, start: new Date('2005-01-14T12:43:00Z') }],
 };
 
 export const CURIOSITY: Spacecraft = {
@@ -234,7 +237,43 @@ export const CURIOSITY: Spacecraft = {
   visited: [{ id: Bodies.MARS.id, type: SpacecraftVisitType.ROVER, start: new Date('2012-08-06T05:17:00Z') }],
 };
 
-export const SPACECRAFT: Array<Spacecraft> = [VOYAGER_1, VOYAGER_2, CASSINI, HUYGENS, CURIOSITY];
+export const PERSEVERANCE: Spacecraft = {
+  name: 'Perseverance',
+  organization: SpacecraftOrganization.NASA,
+  launchMass: 1025,
+  power: 110,
+  start: new Date('2020-07-30T11:50:00Z'),
+  status: { status: SpacecraftStatus.OPERATIONAL },
+  thumbnail: 'perseverance-thumb.jpg',
+  wiki: 'https://en.wikipedia.org/wiki/Perseverance_(rover)',
+  visited: [{ id: Bodies.MARS.id, type: SpacecraftVisitType.ROVER, start: new Date('2021-02-18T20:55:00Z') }],
+};
+
+export const INGENUITY: Spacecraft = {
+  name: 'Ingenuity',
+  organization: SpacecraftOrganization.NASA,
+  launchMass: 1.8,
+  power: 350,
+  start: new Date('2020-07-30T11:50:00Z'),
+  end: new Date('2024-01-18T12:00:00Z'),
+  status: {
+    status: SpacecraftStatus.DEFUNCT,
+    details: 'Retired in 2024 due to sustained rotor damage',
+  },
+  thumbnail: 'ingenuity-thumb.jpg',
+  wiki: 'https://en.wikipedia.org/wiki/Ingenuity_(helicopter)',
+  visited: [{ id: Bodies.MARS.id, type: SpacecraftVisitType.HELICOPTER, start: new Date('2021-02-18T20:55:00Z') }],
+};
+
+export const SPACECRAFT: Array<Spacecraft> = [
+  VOYAGER_1,
+  VOYAGER_2,
+  CASSINI,
+  HUYGENS,
+  CURIOSITY,
+  PERSEVERANCE,
+  INGENUITY,
+];
 
 // TODO: sort by ascending visit date?
 export const SPACECRAFT_BY_BODY_ID = SPACECRAFT.reduce<Record<CelestialBodyId, Array<Spacecraft>>>(

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -113,7 +113,7 @@ export const VOYAGER_2: Spacecraft = {
   power: 470,
   start: new Date('1977-08-20T14:29:00Z'),
   status: { status: SpacecraftStatus.OPERATIONAL },
-  thumbnail: 'voyager-1.png', // twin spacecraft
+  thumbnail: 'voyager-2.jpg',
   wiki: 'https://en.wikipedia.org/wiki/Voyager_2',
   visited: [
     {

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -3,20 +3,29 @@ import { CelestialBodyId } from './types.ts';
 
 export type SpacecraftOrganization = {
   name: string;
+  shortName: string;
   thumbnail: string;
 };
 
 export const NASA: SpacecraftOrganization = {
-  name: 'NASA',
+  name: 'National Aeronautics and Space Administration',
+  shortName: 'NASA',
   thumbnail: 'nasa-meatball.svg',
 };
 export const ESA: SpacecraftOrganization = {
-  name: 'ESA',
-  thumbnail: 'TODO', // TODO
+  name: 'European Space Agency',
+  shortName: 'ESA',
+  thumbnail: 'esa-logo.png',
 };
 export const ROSCOSMOS: SpacecraftOrganization = {
-  name: 'Roscosmos',
-  thumbnail: 'TODO', // TODO
+  name: 'State Corporation for Space Activities',
+  shortName: 'Roscosmos',
+  thumbnail: 'roscosmos-logo.png',
+};
+export const JAXA: SpacecraftOrganization = {
+  name: 'Japan Aerospace Exploration Agency',
+  shortName: 'JAXA',
+  thumbnail: 'jaxa-logo.png',
 };
 
 export enum SpacecraftVisitType {
@@ -110,6 +119,27 @@ export const VOYAGER_2: Spacecraft = {
     { id: Bodies.TETHYS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T06:12:30Z') },
     { id: Bodies.RHEA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T06:28:48Z') },
     { id: Bodies.PHOEBE.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-09-04T01:22:34Z') },
+    {
+      id: Bodies.URANUS.id,
+      type: SpacecraftVisitType.FLYBY,
+      start: new Date('1985-11-04T00:00:00Z'),
+      end: new Date('1986-02-25T00:00:00Z'),
+    },
+    { id: Bodies.MIRANDA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1986-01-24T16:50:00Z') },
+    { id: Bodies.ARIEL.id, type: SpacecraftVisitType.FLYBY, start: new Date('1986-01-24T17:25:00Z') },
+    { id: Bodies.UMBRIEL.id, type: SpacecraftVisitType.FLYBY, start: new Date('1986-01-24T17:25:00Z') },
+    { id: Bodies.TITANIA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1986-01-24T17:25:00Z') },
+    { id: Bodies.OBERON.id, type: SpacecraftVisitType.FLYBY, start: new Date('1986-01-24T17:25:00Z') },
+    {
+      id: Bodies.NEPTUNE.id,
+      type: SpacecraftVisitType.FLYBY,
+      start: new Date('1989-06-05T00:00:00Z'),
+      end: new Date('1989-10-02T00:00:00Z'),
+    },
+    { id: Bodies.GALATEA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1989-08-25T04:41:00Z') },
+    { id: Bodies.LARISSA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1989-08-25T04:51:00Z') },
+    { id: Bodies.PROTEUS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1989-08-25T05:29:00Z') },
+    { id: Bodies.TRITON.id, type: SpacecraftVisitType.FLYBY, start: new Date('1989-08-25T09:23:00Z') },
   ],
 };
 

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -219,7 +219,7 @@ export const HUYGENS: Spacecraft = {
   launchMass: 320,
   power: 600, // 1800 Wh, estimated battery life of 3 hours
   start: new Date('1997-10-15T08:43:00Z'),
-  status: { status: SpacecraftStatus.DEFUNCT },
+  status: { status: SpacecraftStatus.DEFUNCT, details: 'Ran out of battery ~90 minutes after touchdown' },
   thumbnail: 'huygens-thumb.jpg',
   wiki: 'https://en.wikipedia.org/wiki/Huygens_(spacecraft)',
   visited: [{ id: Bodies.TITAN.id, type: SpacecraftVisitType.LANDER, start: new Date('2005-01-14T12:43:00Z') }],
@@ -298,17 +298,41 @@ export const NEW_HORIZONS: Spacecraft = {
   ],
 };
 
-// export const NEW_HORIZONS: Spacecraft = {}
-// export const PARKER_SOLAR_PROBE: Spacecraft = {}
+export const GALILEO: Spacecraft = {
+  name: 'Galileo',
+  organization: SpacecraftOrganization.NASA,
+  launchMass: 2560,
+  power: 570,
+  start: new Date('1989-10-18T16:53:40Z'),
+  status: {
+    status: SpacecraftStatus.DECOMMISSIONED,
+    details: "Intentionally flown into Jupiter's atmosphere on September 21st, 2003",
+  },
+  thumbnail: 'galileo-thumb.png',
+  wiki: 'https://en.wikipedia.org/wiki/Galileo_(spacecraft)',
+  visited: [
+    {
+      id: Bodies.JUPITER.id,
+      type: SpacecraftVisitType.ORBITER,
+      start: new Date('1995-12-07T12:00:00Z'),
+      end: new Date('2003-09-21T12:00:00Z'),
+    },
+    { id: Bodies.IO.id, type: SpacecraftVisitType.FLYBY, start: new Date('1995-12-07T12:00:00Z') },
+    { id: Bodies.GANYMEDE.id, type: SpacecraftVisitType.FLYBY, start: new Date('1996-06-27T12:00:00Z') },
+    { id: Bodies.CALLISTO.id, type: SpacecraftVisitType.FLYBY, start: new Date('1996-12-19T12:00:00Z') },
+    { id: Bodies.EUROPA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1997-02-20T12:00:00Z') },
+    // TODO: Amalthea flyby on 2002-11-04
+  ],
+};
 
 export const SPACECRAFT: Array<Spacecraft> = [
   VOYAGER_1,
   VOYAGER_2,
+  GALILEO,
   CASSINI,
   HUYGENS,
   NEW_HORIZONS,
   // PARKER_SOLAR_PROBE,
-  // GALILEO,
   // MESSENGER,
   // BEPICOLOMBO,
   // SOLAR_ORBITER,

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -1,0 +1,64 @@
+import * as Bodies from './bodies.ts';
+import { CelestialBodyId } from './types.ts';
+
+export type SpacecraftOrganization = {
+  name: string;
+};
+
+export const NASA: SpacecraftOrganization = {
+  name: 'NASA',
+};
+export const ESA: SpacecraftOrganization = {
+  name: 'ESA',
+};
+export const ROSCOSMOS: SpacecraftOrganization = {
+  name: 'Roscosmos',
+};
+
+export enum SpacecraftVisitType {
+  FLYBY = 'flyby',
+  ORBIT = 'orbit',
+  LANDING = 'landing',
+}
+
+export type Spacecraft = {
+  name: string;
+  organization: SpacecraftOrganization;
+  launchMass: number; // kg
+  power: number; // watts
+  start: Date;
+  end?: Date;
+  thumbnail: string;
+  visited: Array<{
+    id: CelestialBodyId;
+    type: SpacecraftVisitType;
+    start: Date;
+    end?: Date;
+  }>;
+};
+
+export const VOYAGER_1: Spacecraft = {
+  name: 'Voyager 1',
+  organization: NASA,
+  launchMass: 815,
+  power: 470,
+  start: new Date('1977-09-05T12:56:01Z'),
+  thumbnail: 'voyager-1.png',
+  visited: [
+    { id: Bodies.JUPITER.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-03-05T12:00:00Z') },
+    { id: Bodies.SATURN.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-12T12:00:00Z') },
+    { id: Bodies.TITAN.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-12T12:00:00Z') },
+  ],
+};
+
+export const SPACECRAFT: Array<Spacecraft> = [VOYAGER_1];
+
+export const SPACECRAFT_BY_BODY_ID = SPACECRAFT.reduce<Record<CelestialBodyId, Array<Spacecraft>>>(
+  (acc, spacecraft) => {
+    spacecraft.visited.forEach(visited => {
+      acc[visited.id] = [...(acc[visited.id] ?? []), spacecraft];
+    });
+    return acc;
+  },
+  {}
+);

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -265,14 +265,118 @@ export const INGENUITY: Spacecraft = {
   visited: [{ id: Bodies.MARS.id, type: SpacecraftVisitType.HELICOPTER, start: new Date('2021-02-18T20:55:00Z') }],
 };
 
+export const NEW_HORIZONS: Spacecraft = {
+  name: 'New Horizons',
+  organization: SpacecraftOrganization.NASA,
+  launchMass: 478,
+  power: 245,
+  start: new Date('2006-01-19T19:00:00Z'),
+  status: {
+    status: SpacecraftStatus.OPERATIONAL,
+    details: 'Currently traveling through the Kuiper belt',
+  },
+  thumbnail: 'new-horizons-thumb.png',
+  wiki: 'https://en.wikipedia.org/wiki/New_Horizons',
+  visited: [
+    // TODO: flyby of asteroid 132524 APL
+    { id: Bodies.JUPITER.id, type: SpacecraftVisitType.FLYBY, start: new Date('2007-02-28T12:00:00Z') },
+    // Pluto phase
+    {
+      id: Bodies.PLUTO.id,
+      type: SpacecraftVisitType.FLYBY,
+      start: new Date('2015-03-10T12:00:00Z'),
+      end: new Date('2015-07-14T12:00:00Z'),
+    },
+    { id: Bodies.CHARON.id, type: SpacecraftVisitType.FLYBY, start: new Date('2015-07-14T12:03:00Z') },
+    { id: Bodies.HYDRA.id, type: SpacecraftVisitType.FLYBY, start: new Date('2015-07-14T12:00:00Z') },
+    { id: Bodies.NIX.id, type: SpacecraftVisitType.FLYBY, start: new Date('2015-07-14T12:00:00Z') },
+    { id: Bodies.KERBEROS.id, type: SpacecraftVisitType.FLYBY, start: new Date('2015-07-14T12:00:00Z') },
+    { id: Bodies.STYX.id, type: SpacecraftVisitType.FLYBY, start: new Date('2015-07-14T12:00:00Z') },
+    // Kuiper belt phase
+    { id: Bodies.ARROKOTH.id, type: SpacecraftVisitType.FLYBY, start: new Date('2019-01-01T12:00:00Z') },
+    // TODO: add 15810 Arawn
+  ],
+};
+
+// export const NEW_HORIZONS: Spacecraft = {}
+// export const PARKER_SOLAR_PROBE: Spacecraft = {}
+
 export const SPACECRAFT: Array<Spacecraft> = [
   VOYAGER_1,
   VOYAGER_2,
   CASSINI,
   HUYGENS,
+  NEW_HORIZONS,
+  // PARKER_SOLAR_PROBE,
+  // GALILEO,
+  // MESSENGER,
+  // BEPICOLOMBO,
+  // SOLAR_ORBITER,
+
+  // Mars
   CURIOSITY,
   PERSEVERANCE,
   INGENUITY,
+  // SOJOURNER,
+  // SPIRIT,
+  // OPPORTUNITY,
+  // ZHURONG,
+  // MARS_2,
+  // MARS_3,
+  // MARS_RECONNAISSANCE_ORBITER,
+  // VIKING_1,
+  // VIKING_2,
+  // MARS_PATHFINDER,
+  // PHOENIX,
+  // INSIGHT,
+
+  // Venus
+  // VENERA_1,
+  // MARINER_2,
+  // ZOND_1,
+  // VENERA_2,
+  // VENERA_3,
+  // VENERA_4,
+  // MARINER_5,
+  // VENERA_5,
+  // VENERA_6,
+  // VENERA_7,
+  // VENERA_8,
+  // MARINER_10,
+  // VENERA_9,
+  // VENERA_10,
+  // VENERA_11,
+  // VENERA_12,
+  // PIONEER_VENUS_1,
+  // PIONEER_VENUS_2,
+  // VENERA_13,
+  // VENERA_14,
+  // VENERA_15,
+  // VENERA_16,
+  // VEGA_1,
+  // VEGA_2,
+  // MAGELLAN,
+  // VENUS_EXPRESS,
+  // AKATSUKI,
+  // IKAROS,
+  // SHINEN,
+
+  // Asteroids
+  // PIONEER_10,
+  // NEAR_SHOEMAKER,
+  // DEEP_SPACE_1,
+  // STARDUST,
+  // HAYABUSA,
+  // ROSETTA,
+  // DEEP_IMPACT,
+  // DAWN,
+  // CHANGE_2,
+  // HAYABUSA_2,
+  // OSIRIS_REX,
+  // LUCY,
+  // DART,
+  // PSYCHE,
+  // HERA,
 ];
 
 // TODO: sort by ascending visit date?

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -32,6 +32,7 @@ export enum SpacecraftVisitType {
   FLYBY = 'flyby',
   ORBIT = 'orbit',
   LANDING = 'landing',
+  GRAVITY_ASSIST = 'gravity assist',
 }
 
 export type Spacecraft = {
@@ -41,9 +42,10 @@ export type Spacecraft = {
   power: number; // watts
   start: Date;
   end?: Date;
-  thumbnail: string;
+  thumbnail?: string;
   wiki: string;
   crew?: Array<string>;
+  // TODO: many spacecraft fly by an object multiple times -- is it worth representing that? tons of data to transcribe
   visited: Array<{
     id: CelestialBodyId;
     type: SpacecraftVisitType;
@@ -143,7 +145,51 @@ export const VOYAGER_2: Spacecraft = {
   ],
 };
 
-export const SPACECRAFT: Array<Spacecraft> = [VOYAGER_1, VOYAGER_2];
+export const CASSINI: Spacecraft = {
+  name: 'Cassini',
+  organization: NASA,
+  launchMass: 5712,
+  power: 885,
+  start: new Date('1997-10-15T08:43:00Z'),
+  // thumbnail: TODO
+  wiki: 'https://en.wikipedia.org/wiki/Cassini%E2%80%93Huygens',
+  visited: [
+    // traveling to Saturn
+    { id: Bodies.VENUS.id, type: SpacecraftVisitType.GRAVITY_ASSIST, start: new Date('1998-04-26T12:00:00Z') },
+    { id: Bodies.LUNA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1999-08-18T03:28:00Z') },
+    // TODO: 2685 Masurksy (asteroid) flyby on 2000-01-23
+    { id: Bodies.JUPITER.id, type: SpacecraftVisitType.GRAVITY_ASSIST, start: new Date('2000-12-30T10:05:00Z') },
+    // primary mission
+    {
+      id: Bodies.SATURN.id,
+      type: SpacecraftVisitType.ORBIT,
+      start: new Date('2004-05-18T12:00:00Z'),
+      end: new Date('2017-09-15T11:55:00Z'),
+    },
+    // TODO: Prometheus, Pandora
+    { id: Bodies.PHOEBE.id, type: SpacecraftVisitType.FLYBY, start: new Date('2004-05-27T12:00:00Z') },
+    { id: Bodies.TITAN.id, type: SpacecraftVisitType.FLYBY, start: new Date('2004-07-02T12:00:00Z') },
+    { id: Bodies.IAPETUS.id, type: SpacecraftVisitType.FLYBY, start: new Date('2004-12-31T18:45:37Z') },
+    { id: Bodies.ENCELADUS.id, type: SpacecraftVisitType.FLYBY, start: new Date('2005-02-17T12:00:00Z') },
+    { id: Bodies.HYPERION.id, type: SpacecraftVisitType.FLYBY, start: new Date('2005-09-26T12:00:00Z') },
+    // solstice+equinox mission
+    { id: Bodies.RHEA.id, type: SpacecraftVisitType.FLYBY, start: new Date('2005-11-26T22:37:00Z') },
+    { id: Bodies.DIONE.id, type: SpacecraftVisitType.FLYBY, start: new Date('2010-04-07T12:00:00Z') },
+  ],
+};
+
+export const HUYGENS: Spacecraft = {
+  name: 'Huygens',
+  organization: ESA,
+  launchMass: 320,
+  power: 600, // 1800 Wh, estimated battery life of 3 hours
+  start: new Date('1997-10-15T08:43:00Z'),
+  // thumbnail: TODO
+  wiki: 'https://en.wikipedia.org/wiki/Huygens_(spacecraft)',
+  visited: [{ id: Bodies.TITAN.id, type: SpacecraftVisitType.LANDING, start: new Date('2005-01-14T12:43:00Z') }],
+};
+
+export const SPACECRAFT: Array<Spacecraft> = [VOYAGER_1, VOYAGER_2, CASSINI, HUYGENS];
 
 // TODO: sort by ascending visit date?
 export const SPACECRAFT_BY_BODY_ID = SPACECRAFT.reduce<Record<CelestialBodyId, Array<Spacecraft>>>(

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -47,10 +47,17 @@ export const SPACECRAFT_ORGANIZATIONS: Record<SpacecraftOrganization, Spacecraft
 };
 
 export enum SpacecraftVisitType {
-  FLYBY = 'flyby',
-  ORBIT = 'orbit',
-  LANDING = 'landing',
-  GRAVITY_ASSIST = 'gravity assist',
+  FLYBY = 'Flyby',
+  ORBIT = 'Orbit',
+  LANDING = 'Landing',
+  ROVER = 'Rover',
+  GRAVITY_ASSIST = 'Gravity Assist',
+}
+
+export enum SpacecraftStatus {
+  OPERATIONAL = 'Operational',
+  DEFUNCT = 'Defunct',
+  CRASHED = 'Crashed',
 }
 
 export type Spacecraft = {
@@ -58,8 +65,9 @@ export type Spacecraft = {
   organization: SpacecraftOrganization;
   launchMass: number; // kg
   power: number; // watts
-  start: Date;
+  start: Date; // TODO: rename to launchDate?
   end?: Date;
+  status: { status: SpacecraftStatus; details?: string };
   thumbnail?: string;
   wiki: string;
   crew?: Array<string>;
@@ -78,6 +86,7 @@ export const VOYAGER_1: Spacecraft = {
   launchMass: 815,
   power: 470,
   start: new Date('1977-09-05T12:56:01Z'),
+  status: { status: SpacecraftStatus.OPERATIONAL },
   thumbnail: 'voyager-1.png',
   wiki: 'https://en.wikipedia.org/wiki/Voyager_1',
   visited: [
@@ -103,6 +112,7 @@ export const VOYAGER_2: Spacecraft = {
   launchMass: 721.9,
   power: 470,
   start: new Date('1977-08-20T14:29:00Z'),
+  status: { status: SpacecraftStatus.OPERATIONAL },
   thumbnail: 'voyager-1.png', // twin spacecraft
   wiki: 'https://en.wikipedia.org/wiki/Voyager_2',
   visited: [
@@ -169,6 +179,10 @@ export const CASSINI: Spacecraft = {
   launchMass: 5712,
   power: 885,
   start: new Date('1997-10-15T08:43:00Z'),
+  status: {
+    status: SpacecraftStatus.CRASHED,
+    details: "Intentionally flown into Saturn's atmosphere on September 15th, 2017",
+  },
   thumbnail: 'cassini-huygens.gif',
   wiki: 'https://en.wikipedia.org/wiki/Cassini%E2%80%93Huygens',
   visited: [
@@ -202,12 +216,25 @@ export const HUYGENS: Spacecraft = {
   launchMass: 320,
   power: 600, // 1800 Wh, estimated battery life of 3 hours
   start: new Date('1997-10-15T08:43:00Z'),
+  status: { status: SpacecraftStatus.DEFUNCT },
   thumbnail: 'huygens-thumb.jpg',
   wiki: 'https://en.wikipedia.org/wiki/Huygens_(spacecraft)',
   visited: [{ id: Bodies.TITAN.id, type: SpacecraftVisitType.LANDING, start: new Date('2005-01-14T12:43:00Z') }],
 };
 
-export const SPACECRAFT: Array<Spacecraft> = [VOYAGER_1, VOYAGER_2, CASSINI, HUYGENS];
+export const CURIOSITY: Spacecraft = {
+  name: 'Curiosity',
+  organization: SpacecraftOrganization.NASA,
+  launchMass: 899,
+  power: 100,
+  start: new Date('2011-11-26T15:02:00Z'),
+  status: { status: SpacecraftStatus.OPERATIONAL },
+  thumbnail: 'curiosity-thumb.jpg',
+  wiki: 'https://en.wikipedia.org/wiki/Curiosity_(rover)',
+  visited: [{ id: Bodies.MARS.id, type: SpacecraftVisitType.ROVER, start: new Date('2012-08-06T05:17:00Z') }],
+};
+
+export const SPACECRAFT: Array<Spacecraft> = [VOYAGER_1, VOYAGER_2, CASSINI, HUYGENS, CURIOSITY];
 
 // TODO: sort by ascending visit date?
 export const SPACECRAFT_BY_BODY_ID = SPACECRAFT.reduce<Record<CelestialBodyId, Array<Spacecraft>>>(

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -1,31 +1,49 @@
 import * as Bodies from './bodies.ts';
 import { CelestialBodyId } from './types.ts';
 
-export type SpacecraftOrganization = {
+export enum SpacecraftOrganization {
+  NASA = 'NASA',
+  ESA = 'ESA',
+  JAXA = 'JAXA',
+  ROSCOSMOS = 'ROSCOSMOS',
+}
+
+export type SpacecraftOrganizationDetails = {
+  organization: SpacecraftOrganization;
   name: string;
   shortName: string;
   thumbnail: string;
 };
 
-export const NASA: SpacecraftOrganization = {
+const NASA: SpacecraftOrganizationDetails = {
+  organization: SpacecraftOrganization.NASA,
   name: 'National Aeronautics and Space Administration',
   shortName: 'NASA',
   thumbnail: 'nasa-meatball.svg',
 };
-export const ESA: SpacecraftOrganization = {
+const ESA: SpacecraftOrganizationDetails = {
+  organization: SpacecraftOrganization.ESA,
   name: 'European Space Agency',
   shortName: 'ESA',
   thumbnail: 'esa-logo.png',
 };
-export const ROSCOSMOS: SpacecraftOrganization = {
+const ROSCOSMOS: SpacecraftOrganizationDetails = {
+  organization: SpacecraftOrganization.ROSCOSMOS,
   name: 'State Corporation for Space Activities',
   shortName: 'Roscosmos',
   thumbnail: 'roscosmos-logo.png',
 };
-export const JAXA: SpacecraftOrganization = {
+const JAXA: SpacecraftOrganizationDetails = {
+  organization: SpacecraftOrganization.JAXA,
   name: 'Japan Aerospace Exploration Agency',
   shortName: 'JAXA',
   thumbnail: 'jaxa-logo.png',
+};
+export const SPACECRAFT_ORGANIZATIONS: Record<SpacecraftOrganization, SpacecraftOrganizationDetails> = {
+  [SpacecraftOrganization.NASA]: NASA,
+  [SpacecraftOrganization.ESA]: ESA,
+  [SpacecraftOrganization.ROSCOSMOS]: ROSCOSMOS,
+  [SpacecraftOrganization.JAXA]: JAXA,
 };
 
 export enum SpacecraftVisitType {
@@ -56,7 +74,7 @@ export type Spacecraft = {
 
 export const VOYAGER_1: Spacecraft = {
   name: 'Voyager 1',
-  organization: NASA,
+  organization: SpacecraftOrganization.NASA,
   launchMass: 815,
   power: 470,
   start: new Date('1977-09-05T12:56:01Z'),
@@ -81,7 +99,7 @@ export const VOYAGER_1: Spacecraft = {
 
 export const VOYAGER_2: Spacecraft = {
   name: 'Voyager 2',
-  organization: NASA,
+  organization: SpacecraftOrganization.NASA,
   launchMass: 721.9,
   power: 470,
   start: new Date('1977-08-20T14:29:00Z'),
@@ -147,11 +165,11 @@ export const VOYAGER_2: Spacecraft = {
 
 export const CASSINI: Spacecraft = {
   name: 'Cassini',
-  organization: NASA,
+  organization: SpacecraftOrganization.NASA,
   launchMass: 5712,
   power: 885,
   start: new Date('1997-10-15T08:43:00Z'),
-  // thumbnail: TODO
+  thumbnail: 'cassini-huygens.gif',
   wiki: 'https://en.wikipedia.org/wiki/Cassini%E2%80%93Huygens',
   visited: [
     // traveling to Saturn
@@ -180,11 +198,11 @@ export const CASSINI: Spacecraft = {
 
 export const HUYGENS: Spacecraft = {
   name: 'Huygens',
-  organization: ESA,
+  organization: SpacecraftOrganization.ESA,
   launchMass: 320,
   power: 600, // 1800 Wh, estimated battery life of 3 hours
   start: new Date('1997-10-15T08:43:00Z'),
-  // thumbnail: TODO
+  thumbnail: 'huygens-thumb.jpg',
   wiki: 'https://en.wikipedia.org/wiki/Huygens_(spacecraft)',
   visited: [{ id: Bodies.TITAN.id, type: SpacecraftVisitType.LANDING, start: new Date('2005-01-14T12:43:00Z') }],
 };
@@ -201,3 +219,15 @@ export const SPACECRAFT_BY_BODY_ID = SPACECRAFT.reduce<Record<CelestialBodyId, A
   },
   {}
 );
+
+export function isSpacecraft(obj: unknown): obj is Spacecraft {
+  return (
+    obj != null &&
+    typeof obj === 'object' &&
+    'name' in obj &&
+    typeof obj.name === 'string' &&
+    'organization' in obj &&
+    typeof obj.organization === 'string' &&
+    Object.values(SpacecraftOrganization).includes(obj.organization as SpacecraftOrganization)
+  );
+}

--- a/src/lib/spacecraft.ts
+++ b/src/lib/spacecraft.ts
@@ -3,16 +3,20 @@ import { CelestialBodyId } from './types.ts';
 
 export type SpacecraftOrganization = {
   name: string;
+  thumbnail: string;
 };
 
 export const NASA: SpacecraftOrganization = {
   name: 'NASA',
+  thumbnail: 'nasa-meatball.svg',
 };
 export const ESA: SpacecraftOrganization = {
   name: 'ESA',
+  thumbnail: 'TODO', // TODO
 };
 export const ROSCOSMOS: SpacecraftOrganization = {
   name: 'Roscosmos',
+  thumbnail: 'TODO', // TODO
 };
 
 export enum SpacecraftVisitType {
@@ -29,6 +33,8 @@ export type Spacecraft = {
   start: Date;
   end?: Date;
   thumbnail: string;
+  wiki: string;
+  crew?: Array<string>;
   visited: Array<{
     id: CelestialBodyId;
     type: SpacecraftVisitType;
@@ -44,15 +50,72 @@ export const VOYAGER_1: Spacecraft = {
   power: 470,
   start: new Date('1977-09-05T12:56:01Z'),
   thumbnail: 'voyager-1.png',
+  wiki: 'https://en.wikipedia.org/wiki/Voyager_1',
   visited: [
     { id: Bodies.JUPITER.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-03-05T12:00:00Z') },
+    // { id: Bodies.AMALTHEA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-03-05T12:00:00Z') }, // TODO
+    { id: Bodies.IO.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-03-05T15:14:00Z') },
+    { id: Bodies.EUROPA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-03-05T18:19:00Z') },
+    { id: Bodies.GANYMEDE.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-03-06T02:15:00Z') },
+    { id: Bodies.CALLISTO.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-03-06T17:08:00Z') },
     { id: Bodies.SATURN.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-12T12:00:00Z') },
-    { id: Bodies.TITAN.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-12T12:00:00Z') },
+    { id: Bodies.TITAN.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-12T05:41:00Z') },
+    { id: Bodies.TETHYS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-12T22:16:00Z') },
+    { id: Bodies.MIMAS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-13T01:43:00Z') },
+    { id: Bodies.ENCELADUS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-13T01:51:00Z') },
+    { id: Bodies.RHEA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-13T06:21:00Z') },
+    { id: Bodies.HYPERION.id, type: SpacecraftVisitType.FLYBY, start: new Date('1980-11-13T16:44:00Z') },
   ],
 };
 
-export const SPACECRAFT: Array<Spacecraft> = [VOYAGER_1];
+export const VOYAGER_2: Spacecraft = {
+  name: 'Voyager 2',
+  organization: NASA,
+  launchMass: 721.9,
+  power: 470,
+  start: new Date('1977-08-20T14:29:00Z'),
+  thumbnail: 'voyager-1.png', // twin spacecraft
+  wiki: 'https://en.wikipedia.org/wiki/Voyager_2',
+  visited: [
+    {
+      id: Bodies.JUPITER.id,
+      type: SpacecraftVisitType.FLYBY,
+      start: new Date('1979-07-08T12:00:00Z'),
+      end: new Date('1979-08-05T12:00:00Z'),
+    },
+    { id: Bodies.CALLISTO.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-07-08T12:21:00Z') },
+    { id: Bodies.GANYMEDE.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-07-09T07:14:00Z') },
+    { id: Bodies.EUROPA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-07-09T17:53:00Z') },
+    // { id: Bodies.AMALTHEA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-07-09T20:01:00Z') }, // TODO
+    { id: Bodies.IO.id, type: SpacecraftVisitType.FLYBY, start: new Date('1979-07-09T23:17:00Z') },
+    {
+      id: Bodies.SATURN.id,
+      type: SpacecraftVisitType.FLYBY,
+      start: new Date('1981-06-05T00:00:00Z'),
+      end: new Date('1981-09-25T00:00:00Z'),
+    },
+    { id: Bodies.IAPETUS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-22T01:26:57Z') },
+    { id: Bodies.HYPERION.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-25T01:25:26Z') },
+    { id: Bodies.TITAN.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-25T09:37:46Z') },
+    // { id: Bodies.HELENE.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-25T22:57:33Z') }, // TODO
+    { id: Bodies.DIONE.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T01:04:32Z') },
+    // { id: Bodies.CALYPSO.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T02:22:17Z') }, // TODO
+    { id: Bodies.MIMAS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T02:24:26Z') },
+    // { id: Bodies.PANDORA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T03:19:18Z') }, // TODO
+    // { id: Bodies.ATLAS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T03:33:02Z') }, // TODO
+    { id: Bodies.ENCELADUS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T03:45:16Z') },
+    // { id: Bodies.JANUS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T03:50:04Z') }, // TODO
+    // { id: Bodies.EPIMETHEUS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T04:05:56Z') }, // TODO
+    // { id: Bodies.TELESTO.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T06:02:47Z') }, // TODO
+    { id: Bodies.TETHYS.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T06:12:30Z') },
+    { id: Bodies.RHEA.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-08-26T06:28:48Z') },
+    { id: Bodies.PHOEBE.id, type: SpacecraftVisitType.FLYBY, start: new Date('1981-09-04T01:22:34Z') },
+  ],
+};
 
+export const SPACECRAFT: Array<Spacecraft> = [VOYAGER_1, VOYAGER_2];
+
+// TODO: sort by ascending visit date?
 export const SPACECRAFT_BY_BODY_ID = SPACECRAFT.reduce<Record<CelestialBodyId, Array<Spacecraft>>>(
   (acc, spacecraft) => {
     spacecraft.visited.forEach(visited => {


### PR DESCRIPTION
Set up a `Spacecraft` type with details about the vehicle and the bodies it visited and display this on the fact sheets:

<img width="588" alt="Screenshot 2025-01-25 at 4 30 42 PM" src="https://github.com/user-attachments/assets/7a71817f-f09d-4e9d-a0f7-4d54e9087ce8" />

Follow-ups will include:

- Define more spacecraft (token set of ~10 missions currently defined)
- Add dedicated fact sheet for each spacecraft (currently just links to the Wikipedia page)
  - Add spacecraft to omnibox (requires dedicated fact sheet)
- Show trajectory or current position or mission replay (challenge!)