### PR TITLE
Update firmament texture to one with the Milky Way

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Infrastructure dependencies:
   - [ ] Use ephemeris data for modeling
 - Scene rendering:
   - [ ] Examine render settings, see if visuals can be improved
-    - [ ] Fix sporadic black blocks rendering around focus body
+    - [x] Fix sporadic black blocks rendering around focus body
   - [ ] Fix alignment between planet and ellipse
   - [ ] Render 3D models for asteroids
 - General:

--- a/src/components/FactSheet/CelestialBodyFactSheet.tsx
+++ b/src/components/FactSheet/CelestialBodyFactSheet.tsx
@@ -79,7 +79,7 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
       <FactSheetTitle
         title={body.name}
         subTitle={celestialBodyTypeDescription(body)}
-        color={body.color}
+        color={body.style.fgColor}
         onClose={() => updateSettings({ center: null })}
         onHover={hovered => updateSettings({ hover: hovered ? body.id : null })}
       />

--- a/src/components/FactSheet/FactSheetTitle.tsx
+++ b/src/components/FactSheet/FactSheetTitle.tsx
@@ -1,12 +1,13 @@
 import { ActionIcon, Box, Group, Title } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 import { useDisplaySize } from '../../hooks/useDisplaySize.ts';
+import { HexColor } from '../../lib/types.ts';
 import { iconSize } from '../Controls/constants.ts';
 
 type Props = {
   title: string;
   subTitle: string;
-  color: `#${string}`;
+  color: HexColor;
   onClose: () => void;
   onHover?: (hovered: boolean) => void;
 };

--- a/src/components/SolarSystem.tsx
+++ b/src/components/SolarSystem.tsx
@@ -103,7 +103,7 @@ export function SolarSystem() {
     const focusRegime = ORBITAL_REGIMES.find(({ id }) => id === settings.center);
     return focusBody ?? focusRegime;
   }, [settings.center, JSON.stringify(settings.bodies)]);
-  const focusColor = isCelestialBody(focusItem) ? focusItem.color : DEFAULT_ORBITAL_REGIME_COLOR;
+  const focusColor = isCelestialBody(focusItem) ? focusItem.style.fgColor : DEFAULT_ORBITAL_REGIME_COLOR;
 
   const LayoutComponent = isSmallDisplay ? Stack : Group;
   return (

--- a/src/lib/bodies.ts
+++ b/src/lib/bodies.ts
@@ -6,7 +6,6 @@ import { celestialBodyWithDefaults } from './utils.ts';
 
 export const AU = 1.495978707e11; // meters;
 export const g = 9.807; // earth gravity
-export const ECLIPTIC_TILT = 60; // degrees of tilt between ecliptic and galactic plane
 
 export const SOL = celestialBodyWithDefaults({
   type: CelestialBodyType.STAR,

--- a/src/lib/bodies.ts
+++ b/src/lib/bodies.ts
@@ -28,7 +28,7 @@ export const SOL = celestialBodyWithDefaults({
     axialTilt: 7.25,
     siderealPeriod: 609.12 * Time.HOUR, // 609 hours at 16º latitude; true period varies by latitude
   },
-  color: '#fa0',
+  style: { fgColor: '#fa0' },
   assets: {
     thumbnail: 'sol-thumb.jpg',
     texture: 'sol-texture.jpg',
@@ -62,7 +62,7 @@ export const MERCURY = celestialBodyWithDefaults({
     axialTilt: 0.034,
     siderealPeriod: 58.6467 * Time.DAY,
   },
-  color: '#b3aeae',
+  style: { fgColor: '#b3aeae' },
   assets: {
     thumbnail: 'mercury-thumb.jpg',
     texture: 'mercury-texture.jpg',
@@ -97,7 +97,7 @@ export const VENUS = celestialBodyWithDefaults({
     axialTilt: 2.64, // TODO: retrograde; is this modeled correctly?
     siderealPeriod: -243.02 * Time.DAY, // negative for retrograde rotation
   },
-  color: '#e6b667',
+  style: { fgColor: '#e6b667' },
   assets: {
     thumbnail: 'venus-thumb.jpg',
     texture: 'venus-texture.jpg',
@@ -132,7 +132,7 @@ export const EARTH = celestialBodyWithDefaults({
     axialTilt: -23.4, // TODO: this points it in the right direction -- should all axial tilts be in this direction?
     siderealPeriod: 23 * Time.HOUR + 56 * Time.MINUTE + 4.1, // 23h 56 m 4.100s
   },
-  color: '#7e87dd',
+  style: { fgColor: '#7e87dd' },
   assets: {
     thumbnail: 'earth-thumb.jpg',
     texture: 'earth-texture.jpg',
@@ -200,7 +200,7 @@ export const MARS = celestialBodyWithDefaults({
     axialTilt: 25.19,
     siderealPeriod: Time.DAY + 37 * Time.MINUTE + 22.66, // 24 hr 37 min 22.66 sec
   },
-  color: '#c96c3c',
+  style: { fgColor: '#c96c3c' },
   assets: {
     thumbnail: 'mars-thumb.jpg',
     texture: 'mars-texture.jpg',
@@ -869,7 +869,7 @@ export const PLUTO = celestialBodyWithDefaults({
     axialTilt: 122.53,
     siderealPeriod: 6 * Time.DAY + 9 * Time.HOUR + 17.6 * Time.MINUTE, // - 6 days 9 hr 17.6 min (sideways)
   },
-  color: '#E7C7A4',
+  style: { fgColor: '#E7C7A4' },
   assets: { thumbnail: 'pluto-thumb.jpg' },
 });
 
@@ -1255,7 +1255,7 @@ export const JUPITER = celestialBodyWithDefaults({
     axialTilt: 3.13,
     siderealPeriod: 9 * Time.HOUR + 55 * Time.MINUTE + 30, // 9 hr 55 min 30 sec
   },
-  color: '#e9be76',
+  style: { fgColor: '#e9be76' },
   assets: {
     thumbnail: 'jupiter-thumb.jpg',
     texture: 'jupiter-texture.jpg',
@@ -1278,7 +1278,7 @@ export const IO = celestialBodyWithDefaults({
   },
   mass: 8.931938e22,
   radius: 1821.6e3,
-  color: '#fcf794',
+  style: { fgColor: '#fcf794' },
   assets: { thumbnail: 'io-thumb.jpg' },
 });
 
@@ -1298,7 +1298,7 @@ export const EUROPA = celestialBodyWithDefaults({
   },
   mass: 4.799844e22,
   radius: 1560.8e3,
-  color: '#bfcccb',
+  style: { fgColor: '#bfcccb' },
   assets: { thumbnail: 'europa-thumb.jpg' },
   facts: [
     {
@@ -1381,7 +1381,7 @@ export const SATURN = celestialBodyWithDefaults({
       texture: 'saturn-rings-texture.png',
     },
   ],
-  color: '#d7be87',
+  style: { fgColor: '#d7be87' },
   assets: {
     thumbnail: 'saturn-thumb.jpg',
     texture: 'saturn-texture.jpg',
@@ -1499,7 +1499,7 @@ export const TITAN = celestialBodyWithDefaults({
   },
   mass: 1.3452e23,
   radius: 2574.7e3,
-  color: '#f1e193',
+  style: { fgColor: '#f1e193' },
   assets: {
     thumbnail: 'titan-thumb.jpg',
     gallery: [{ filename: 'huygens-descent.mp4' }, { filename: 'huygens.jpg' }],
@@ -1590,7 +1590,7 @@ export const URANUS = celestialBodyWithDefaults({
     axialTilt: 82.23, // TODO: retrograde -- modeled correctly?
     siderealPeriod: -17 * Time.HOUR + 14 * Time.MINUTE + 24, // -17 hr 14 min 24 sec
   },
-  color: '#9bcee6',
+  style: { fgColor: '#9bcee6' },
   // rings: [], // TODO
   assets: {
     thumbnail: 'uranus-thumb.jpg',
@@ -1735,7 +1735,7 @@ export const NEPTUNE = celestialBodyWithDefaults({
     axialTilt: 28.32,
     siderealPeriod: 16 * Time.HOUR + 6.6 * Time.MINUTE, // 16 hr 6.6 min
   },
-  color: '#5a7cf6',
+  style: { fgColor: '#5a7cf6' },
   assets: {
     thumbnail: 'neptune-thumb.jpg',
     texture: 'neptune-texture.jpg',

--- a/src/lib/canvas.ts
+++ b/src/lib/canvas.ts
@@ -58,7 +58,8 @@ export function drawOffscreenIndicator(
 export function drawLabelAtLocation(
   ctx: CanvasRenderingContext2D,
   label: string,
-  color: `#${string}`,
+  textColor: `#${string}`,
+  strokeColor: `#${string}`,
   [xPx, yPx]: Point2,
   [textWidthPx, textHeightPx]: Point2,
   radius: number
@@ -94,12 +95,12 @@ export function drawLabelAtLocation(
   offsets.forEach(([x, y]) => ctx.lineTo(x0 + x * xSign, y0 - y * ySign));
   ctx.closePath();
   ctx.fillStyle = 'black';
-  ctx.strokeStyle = color;
+  ctx.strokeStyle = strokeColor;
   ctx.fill();
   ctx.stroke();
 
   // draw text
-  ctx.fillStyle = color;
+  ctx.fillStyle = textColor;
   ctx.fillText(label, xIsCloseToRightEdge ? x0 - w : x0 + h / 2, y0 - boxPadPx + (yIsCloseToTopEdge ? h : 0));
   ctx.restore();
 

--- a/src/lib/canvas.ts
+++ b/src/lib/canvas.ts
@@ -1,4 +1,4 @@
-import { Point2 } from './types.ts';
+import { HexColor, Point2 } from './types.ts';
 
 export const LABEL_FONT_FAMILY = 'Electrolize, sans-serif';
 
@@ -25,7 +25,7 @@ export function isLabelFontAvailable(ctx: CanvasRenderingContext2D) {
 // TODO: corners behave weirdly with this implementation; may want 4 more types for the corners
 export function drawOffscreenIndicator(
   ctx: CanvasRenderingContext2D,
-  color: `#${string}`,
+  color: HexColor,
   [canvasWidthPx, canvasHeightPx]: Point2,
   [xPx, yPx]: Point2
 ) {
@@ -58,8 +58,8 @@ export function drawOffscreenIndicator(
 export function drawLabelAtLocation(
   ctx: CanvasRenderingContext2D,
   label: string,
-  textColor: `#${string}`,
-  strokeColor: `#${string}`,
+  textColor: HexColor,
+  strokeColor: HexColor,
   [xPx, yPx]: Point2,
   [textWidthPx, textHeightPx]: Point2,
   radius: number
@@ -111,7 +111,7 @@ export function drawLabelAtLocation(
 
 export function drawDotAtLocation(
   ctx: CanvasRenderingContext2D,
-  color: `#${string}`,
+  color: HexColor,
   [xPx, yPx]: Point2, // centered on this value
   radiusPx: number
 ) {
@@ -125,7 +125,7 @@ export function drawDotAtLocation(
 type CaretType = 'right' | 'left' | 'up' | 'down';
 function drawCaretAtLocation(
   ctx: CanvasRenderingContext2D,
-  color: `#${string}`,
+  color: HexColor,
   [xPx, yPx]: Point2, // centered on this value
   type: CaretType
 ) {

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -3,5 +3,3 @@ const CDN_URL = 'https://atlasofspace.b-cdn.net';
 export function asCdnUrl(filename: string) {
   return `${CDN_URL}/${filename}`;
 }
-
-export const FIRMAMENT_TEXTURE_URL = asCdnUrl('firmament.webp');

--- a/src/lib/model/AxisIndicator.ts
+++ b/src/lib/model/AxisIndicator.ts
@@ -3,6 +3,7 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { LineSegments2 } from 'three/examples/jsm/lines/LineSegments2.js';
 import { LineSegmentsGeometry } from 'three/examples/jsm/lines/LineSegmentsGeometry.js';
 import { degreesToRadians } from '../physics.ts';
+import { CelestialBody } from '../types.ts';
 import { HOVER_SCALE_FACTOR, SCALE_FACTOR } from './constants.ts';
 
 export class AxisIndicator {
@@ -14,19 +15,20 @@ export class AxisIndicator {
   private readonly rotationEuler: Euler;
   private readonly segments: [Vector3, Vector3, Vector3, Vector3];
 
-  constructor(scene: Scene, resolution: Vector2, center: Vector3, axialTilt: number, bodyRadius: number, color: Color) {
+  constructor(scene: Scene, resolution: Vector2, body: CelestialBody, center: Vector3) {
     this.scene = scene;
-    this.bodyRadius = bodyRadius;
+    this.bodyRadius = body.radius;
 
     this.group = new Group();
     this.group.position.copy(center).divideScalar(SCALE_FACTOR);
     this.scene.add(this.group);
 
-    this.rotationEuler = new Euler(degreesToRadians(axialTilt), 0, 0);
+    this.rotationEuler = new Euler(degreesToRadians(body.rotation?.axialTilt ?? 0), 0, 0);
     this.segments = [new Vector3(), new Vector3(), new Vector3(), new Vector3()];
 
     const geometry = new LineSegmentsGeometry();
     geometry.setPositions(this.calculatePositions());
+    const color = new Color(body.style.bgColor ?? body.style.fgColor);
     const material = new LineMaterial({ color, linewidth: 1, resolution, depthTest: true });
     material.depthTest = true;
     this.line = new LineSegments2(geometry, material);

--- a/src/lib/model/FocalRadius.ts
+++ b/src/lib/model/FocalRadius.ts
@@ -2,6 +2,7 @@ import { Color, Group, Material, Scene, Vector2, Vector3 } from 'three';
 import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { CelestialBody } from '../types.ts';
 import { SCALE_FACTOR } from './constants.ts';
 
 export class FocalRadius {
@@ -9,7 +10,7 @@ export class FocalRadius {
   private readonly group: Group;
   private readonly line: Line2;
 
-  constructor(scene: Scene, resolution: Vector2, parentPosition: Vector3, bodyPosition: Vector3, color: Color) {
+  constructor(scene: Scene, resolution: Vector2, body: CelestialBody, parentPosition: Vector3, bodyPosition: Vector3) {
     this.scene = scene;
 
     this.group = new Group();
@@ -19,6 +20,7 @@ export class FocalRadius {
     const geometry = new LineGeometry();
     const { x: px, y: py, z: pz } = bodyPosition.clone().sub(parentPosition).divideScalar(SCALE_FACTOR);
     geometry.setPositions([0, 0, 0, px, py, pz]);
+    const color = new Color(body.style.bgColor ?? body.style.fgColor);
     const material = new LineMaterial({ color, linewidth: 1, resolution, depthTest: true });
     this.line = new Line2(geometry, material);
     this.line.visible = false;

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -1,4 +1,4 @@
-import { Box2, Color, OrthographicCamera, Scene, Vector2, Vector3 } from 'three';
+import { Box2, OrthographicCamera, Scene, Vector2, Vector3 } from 'three';
 import {
   drawDotAtLocation,
   drawLabelAtLocation,
@@ -47,13 +47,12 @@ export class KeplerianBody extends KinematicBody {
     this.body = body;
     this.resolution = resolution;
     this.visible = this.isVisible(settings);
-    const color = new Color(body.style.bgColor ?? body.style.fgColor);
-    this.ellipse = new OrbitalEllipse(scene, resolution, body.elements, parent?.position ?? null, position, color);
-    this.radius = new FocalRadius(scene, resolution, parent?.position ?? new Vector3(), position, color);
+    this.ellipse = new OrbitalEllipse(scene, resolution, body, parent?.position ?? null, position);
+    this.radius = new FocalRadius(scene, resolution, body, parent?.position ?? new Vector3(), position);
     this.sphere = new SphericalBody(scene, body, position);
     this.dotRadius = KeplerianBody.getDotRadius(body);
     if (body.rotation != null) {
-      this.axis = new AxisIndicator(scene, resolution, this.position, body.rotation.axialTilt, body.radius, color);
+      this.axis = new AxisIndicator(scene, resolution, body, this.position);
     }
   }
 

--- a/src/lib/model/OrbitalEllipse.ts
+++ b/src/lib/model/OrbitalEllipse.ts
@@ -19,7 +19,7 @@ import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
 import { degreesToRadians, semiMinorAxis } from '../physics.ts';
-import { KeplerianElements } from '../types.ts';
+import { CelestialBody } from '../types.ts';
 import { SCALE_FACTOR } from './constants.ts';
 
 export class OrbitalEllipse {
@@ -34,10 +34,9 @@ export class OrbitalEllipse {
   constructor(
     scene: Scene,
     resolution: Vector2,
-    elements: KeplerianElements,
+    body: CelestialBody,
     parentPosition: Vector3 | null,
-    bodyPosition: Vector3,
-    color: Color
+    bodyPosition: Vector3
   ) {
     this.scene = scene;
 
@@ -62,7 +61,7 @@ export class OrbitalEllipse {
       longitudeAscending: OmegaDeg,
       argumentOfPeriapsis: omegaDeg,
       inclination: iDeg,
-    } = elements;
+    } = body.elements;
     const a = semiMajorAxis / SCALE_FACTOR;
     const b = semiMinorAxis(a, e);
     const focusDistance = Math.sqrt(a ** 2 - b ** 2);
@@ -90,11 +89,12 @@ export class OrbitalEllipse {
     const ellipseSplinePoints = ellipseSpline.getPoints(this.nPoints * 2); // 2x points for smoother interpolation
 
     const ellipseGeometry = new BufferGeometry().setFromPoints(ellipseSplinePoints);
-    const ellipseMaterial = new LineBasicMaterial({ color });
+    const ellipseMaterial = new LineBasicMaterial({ color: new Color(body.style.bgColor ?? body.style.fgColor) });
     this.ellipse = new Line(ellipseGeometry, ellipseMaterial);
     this.ellipse.renderOrder = 0;
     this.bodyGroup.add(this.ellipse);
 
+    const color = new Color(body.style.fgColor);
     const ellipseHoverGeometry = new LineGeometry().setFromPoints(ellipseSplinePoints);
     const ellipseHoverMaterial = new LineMaterial({ color, linewidth: 2, resolution, depthTest: true });
     this.ellipseHover = new Line2(ellipseHoverGeometry, ellipseHoverMaterial);

--- a/src/lib/model/RingObject.ts
+++ b/src/lib/model/RingObject.ts
@@ -42,7 +42,7 @@ export class RingObject {
       const textureMap = new TextureLoader().load(asCdnUrl(ring.texture));
       material = new MeshStandardMaterial({ map: textureMap, side: DoubleSide });
     } else {
-      material = new MeshBasicMaterial({ color: new Color(body.color) });
+      material = new MeshBasicMaterial({ color: new Color(body.style.fgColor) });
     }
     this.ring = new Mesh(geometry, material);
     this.ring.rotation.x =

--- a/src/lib/model/SphericalBody.ts
+++ b/src/lib/model/SphericalBody.ts
@@ -66,7 +66,7 @@ export class SphericalBody {
   }
 
   private getShapeMaterial(): Material {
-    const color = new Color(this.body.color);
+    const color = new Color(this.body.style.fgColor);
     const texture = this.body.assets?.texture;
     const emissive = this.body.type === CelestialBodyType.STAR;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,12 @@ export enum HeliocentricOrbitalRegime {
   INNER_OORT_CLOUD = 'inner-oort-cloud',
 }
 
+export type HexColor = `#${string}`;
+export type CelestialBodyStyle = {
+  fgColor: HexColor; // main color for the body
+  bgColor?: HexColor; // when absent, use fgColor -- used for orbit ellipses and other "background" elements
+};
+
 export type CelestialBody = {
   id: CelestialBodyId;
   type: CelestialBodyType;
@@ -101,7 +107,7 @@ export type CelestialBody = {
   elements: KeplerianElements;
   rotation?: RotationElements; // leave empty to omit spin
   rings?: Array<Ring>;
-  color: `#${string}`; // hex
+  style: CelestialBodyStyle;
   assets?: CelestialBodyAssets;
   facts?: Array<CelestialBodyFact>;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -75,6 +75,7 @@ const DEFAULT_CELESTIAL_BODY_FG_COLOR: { [T in CelestialBodyType]?: HexColor } =
   [CelestialBodyType.SPACECRAFT]: '#50C878',
 };
 const DEFAULT_CELESTIAL_BODY_BG_COLOR: { [T in CelestialBodyType]?: HexColor } = {
+  [CelestialBodyType.MOON]: '#888888',
   [CelestialBodyType.ASTEROID]: '#4b4b4b',
   [CelestialBodyType.DWARF_PLANET]: '#80747f',
 };
@@ -86,7 +87,7 @@ export function celestialBodyWithDefaults(
     id: body.id ?? celestialBodyNameToId(body.name, body.shortName),
     style: {
       fgColor: body.style?.fgColor ?? DEFAULT_CELESTIAL_BODY_FG_COLOR[body.type] ?? DEFAULT_ASTEROID_COLOR,
-      bgColor: body.style?.bgColor ?? DEFAULT_CELESTIAL_BODY_BG_COLOR[body.type],
+      bgColor: body.style?.bgColor ?? body.style?.fgColor ?? DEFAULT_CELESTIAL_BODY_BG_COLOR[body.type],
     },
   };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -77,7 +77,7 @@ const DEFAULT_CELESTIAL_BODY_FG_COLOR: { [T in CelestialBodyType]?: HexColor } =
 const DEFAULT_CELESTIAL_BODY_BG_COLOR: { [T in CelestialBodyType]?: HexColor } = {
   [CelestialBodyType.MOON]: '#888888',
   [CelestialBodyType.ASTEROID]: '#4b4b4b',
-  [CelestialBodyType.DWARF_PLANET]: '#80747f',
+  [CelestialBodyType.DWARF_PLANET]: '#6e636d',
 };
 export function celestialBodyWithDefaults(
   body: Omit<CelestialBody, 'id' | 'style'> & { id?: string; style?: CelestialBodyStyle }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { AU } from './bodies.ts';
 import { Time } from './epoch.ts';
-import { CelestialBody, CelestialBodyType } from './types.ts';
+import { CelestialBody, CelestialBodyStyle, CelestialBodyType } from './types.ts';
 
 export function pluralize(n: number, unit: string) {
   const nAbs = Math.abs(n);
@@ -66,7 +66,8 @@ export function celestialBodyNameToId(name: string, shortName?: string) {
   return (shortName ?? name).replace(/\s+/g, '-').toLowerCase();
 }
 
-const DEFAULT_ASTEROID_COLOR = '#6b6b6b'; // dark gray, typical for S-type asteroids
+const DEFAULT_ASTEROID_COLOR = '#8b8b8b'; // dark gray, typical for S-type asteroids
+const DEFAULT_ASTEROID_ORBIT_COLOR = '#4b4b4b';
 const DEFAULT_CELESTIAL_BODY_COLOR: { [T in CelestialBodyType]?: `#${string}` } = {
   [CelestialBodyType.MOON]: '#aaaaaa',
   [CelestialBodyType.ASTEROID]: DEFAULT_ASTEROID_COLOR,
@@ -75,11 +76,15 @@ const DEFAULT_CELESTIAL_BODY_COLOR: { [T in CelestialBodyType]?: `#${string}` } 
   [CelestialBodyType.SPACECRAFT]: '#50C878',
 };
 export function celestialBodyWithDefaults(
-  body: Omit<CelestialBody, 'id' | 'color'> & { id?: string; color?: CelestialBody['color'] }
+  body: Omit<CelestialBody, 'id' | 'style'> & { id?: string; style?: CelestialBodyStyle }
 ): CelestialBody {
+  const asteroidOrbitColor = body.type === CelestialBodyType.ASTEROID ? DEFAULT_ASTEROID_ORBIT_COLOR : undefined;
   return {
     ...body,
     id: body.id ?? celestialBodyNameToId(body.name, body.shortName),
-    color: body.color ?? DEFAULT_CELESTIAL_BODY_COLOR[body.type] ?? DEFAULT_ASTEROID_COLOR,
+    style: {
+      fgColor: body.style?.fgColor ?? DEFAULT_CELESTIAL_BODY_COLOR[body.type] ?? DEFAULT_ASTEROID_COLOR,
+      bgColor: body.style?.bgColor ?? asteroidOrbitColor,
+    },
   };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { AU } from './bodies.ts';
 import { Time } from './epoch.ts';
-import { CelestialBody, CelestialBodyStyle, CelestialBodyType } from './types.ts';
+import { CelestialBody, CelestialBodyStyle, CelestialBodyType, HexColor } from './types.ts';
 
 export function pluralize(n: number, unit: string) {
   const nAbs = Math.abs(n);
@@ -67,24 +67,26 @@ export function celestialBodyNameToId(name: string, shortName?: string) {
 }
 
 const DEFAULT_ASTEROID_COLOR = '#8b8b8b'; // dark gray, typical for S-type asteroids
-const DEFAULT_ASTEROID_ORBIT_COLOR = '#4b4b4b';
-const DEFAULT_CELESTIAL_BODY_COLOR: { [T in CelestialBodyType]?: `#${string}` } = {
+const DEFAULT_CELESTIAL_BODY_FG_COLOR: { [T in CelestialBodyType]?: HexColor } = {
   [CelestialBodyType.MOON]: '#aaaaaa',
   [CelestialBodyType.ASTEROID]: DEFAULT_ASTEROID_COLOR,
   [CelestialBodyType.COMET]: '#51807c',
-  [CelestialBodyType.DWARF_PLANET]: '#80747f',
+  [CelestialBodyType.DWARF_PLANET]: '#998a98',
   [CelestialBodyType.SPACECRAFT]: '#50C878',
+};
+const DEFAULT_CELESTIAL_BODY_BG_COLOR: { [T in CelestialBodyType]?: HexColor } = {
+  [CelestialBodyType.ASTEROID]: '#4b4b4b',
+  [CelestialBodyType.DWARF_PLANET]: '#80747f',
 };
 export function celestialBodyWithDefaults(
   body: Omit<CelestialBody, 'id' | 'style'> & { id?: string; style?: CelestialBodyStyle }
 ): CelestialBody {
-  const asteroidOrbitColor = body.type === CelestialBodyType.ASTEROID ? DEFAULT_ASTEROID_ORBIT_COLOR : undefined;
   return {
     ...body,
     id: body.id ?? celestialBodyNameToId(body.name, body.shortName),
     style: {
-      fgColor: body.style?.fgColor ?? DEFAULT_CELESTIAL_BODY_COLOR[body.type] ?? DEFAULT_ASTEROID_COLOR,
-      bgColor: body.style?.bgColor ?? asteroidOrbitColor,
+      fgColor: body.style?.fgColor ?? DEFAULT_CELESTIAL_BODY_FG_COLOR[body.type] ?? DEFAULT_ASTEROID_COLOR,
+      bgColor: body.style?.bgColor ?? DEFAULT_CELESTIAL_BODY_BG_COLOR[body.type],
     },
   };
 }


### PR DESCRIPTION
Also improve colors by setting an optional `bgColor` used for things like orbital ellipses — allows "muting" of the prominence of different ellipses, leveraged to make asteroids less prominent than larger bodies.