### PR TITLE
Hide offscreen indicators on mobile

### DIFF
--- a/src/components/FactSheet/Spacecraft/MissionTimeline.tsx
+++ b/src/components/FactSheet/Spacecraft/MissionTimeline.tsx
@@ -185,7 +185,7 @@ function renderTimeline(ctx: CanvasRenderingContext2D, items: Array<TimelineItem
     const elapsedMillis = date.getTime() - startMillis;
     const timelineY = elapsedMillis / millisPerPx + dotRadius;
     // TODO: the lane behavior here can be dramatically improved
-    const laneIndex = i < nLanes ? nLanes - i : i % nLanes;
+    const laneIndex = Math.min(i, 2 * (nLanes - 1) - i);
     const laneX = laneGutter + laneIndex * laneWidth;
     const itemY = top + height / 2;
     const isGoingUp = timelineY < itemY;

--- a/src/hooks/useDisplaySize.ts
+++ b/src/hooks/useDisplaySize.ts
@@ -1,6 +1,10 @@
 export function useDisplaySize() {
-  return {
-    sm: window.innerWidth < 1080,
-    xs: window.innerWidth < 640,
-  };
+  return { sm: isSm(), xs: isXs() };
+}
+
+export function isXs() {
+  return window.innerWidth < 640;
+}
+export function isSm() {
+  return window.innerWidth < 1080;
 }

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -108,10 +108,9 @@ export class KeplerianBody extends KinematicBody {
     const textColor = this.body.style.fgColor;
     const strokeColor = this.body.style.bgColor ?? this.body.style.fgColor;
 
-    // body is off-screen; draw a pointer
+    // body is off-screen; draw a pointer if the screen is larger than xs (mobile)
     if (isOffScreen(bodyPx, [this.resolution.x, this.resolution.y])) {
-      // TODO: how to always draw moon offscreen indicators underneath parent? better yet, don't draw offscreen
-      //  indicators for moons when the parent isn't visible
+      // TODO: don't draw offscreen indicators for moons when the parent isn't visible
       if (!isXs()) {
         drawOffscreenIndicator(ctx, strokeColor, canvasPx, bodyPx);
       }

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -1,4 +1,5 @@
 import { Box2, OrthographicCamera, Scene, Vector2, Vector3 } from 'three';
+import { isXs } from '../../hooks/useDisplaySize.ts';
 import {
   drawDotAtLocation,
   drawLabelAtLocation,
@@ -111,7 +112,9 @@ export class KeplerianBody extends KinematicBody {
     if (isOffScreen(bodyPx, [this.resolution.x, this.resolution.y])) {
       // TODO: how to always draw moon offscreen indicators underneath parent? better yet, don't draw offscreen
       //  indicators for moons when the parent isn't visible
-      drawOffscreenIndicator(ctx, strokeColor, canvasPx, bodyPx);
+      if (!isXs()) {
+        drawOffscreenIndicator(ctx, strokeColor, canvasPx, bodyPx);
+      }
     } else {
       const baseRadius = this.body.radius / metersPerPx;
       const bodyRadius = this.hovered ? baseRadius * HOVER_SCALE_FACTOR : baseRadius;


### PR DESCRIPTION
These add clutter when the screen is too small.