### PR TITLE
Update extra facts system prompt

### DIFF
--- a/functions/facts.ts
+++ b/functions/facts.ts
@@ -100,52 +100,38 @@ What facts can you tell me about '${search}'? I'm interested in things like the 
 - Discovery date
 - Discoverer and circumstances
 - Information about name and origins
-- Dimensions
-- Rotation period (if known)
+- Dimensions (for non-spherical small bodies only)
+- Rotation facts (e.g. tidally locked or not)
 - Albedo
 - Material composition (if known)
+- Density (if known)
+
+I'm not interested in the following:
+
+- Rotation period (if known)
 - Relevant spacecraft missions and dates
 - Major satellites (if any)
 
-Format your answer as markdown bullet points, with **bolded** keys. Do not include orbital characteristics. Do not preface your \
-answer or return anything other than bullet points.
+Format your answer as markdown bullet points, with **bolded** keys. Do not include orbital characteristics. Do not \
+preface your answer or return anything other than bullet points.
 
-Here's an example of a good response for Saturn's moon Enceladus:
+Here are a few examples of good responses:
 
-\`\`\`md
+<example name="Saturn's moon Enceladus">
 - **Discovery date**: August 28, 1789
 - **Discovered by**: William Herschel, a German-British astronomer
 - **Name origins**: Named after the giant Enceladus from Greek mythology
-- **Dimensions**: Diameter of 504.2 km
-- **Rotation period**: 1.370218 days, tidally locked to Saturn
+- **Rotation**: Tidally locked to Saturn
 - **Albedo**: 1.375
 - **Material composition**: Mostly water ice with some rock
-- **Spacecraft missions**: 
-  - Voyager 1 and Voyager 2 flybys in 1980 and 1981
-  - Cassini orbiter observations from 2004 to 2017
-\`\`\`
+</example>
 
-Here's another good example for the planet Jupiter:
-
-\`\`\`md
+<example name="Jupiter+planet">
 - **Discovery date**: Visible to naked eye since ancient times
 - **Name origins**: Named after the Roman king of gods, Jupiter
-- **Dimensions**: Diameter: 142,984 km
-- **Rotation period**: 9.925 hours
 - **Albedo**: 0.343
 - **Material composition**: Primarily hydrogen and helium gas giant with liquid metallic hydrogen core
-- **Spacecraft missions**:
-  - Pioneer 10 and 11 (1973-1974)
-  - Voyager 1 and 2 (1979)
-  - Galileo orbiter (1995-2003)
-  - Juno orbiter (2016-present)
-- **Satellites**:
-  - Io
-  - Europa
-  - Ganymede
-  - Callisto
-  - At least 91 other minor moons
-\`\`\`
+</example>
 
 I've collected this data from Wikidata to help you provide this information:
 
@@ -166,6 +152,7 @@ ${wikidataInfoAsCsv(wikidataInfo)}
 export default async function handle(request: Request) {
   const params = new URL(request.url).searchParams;
   const search = params.get('search');
+  const blobId = params.get('blobId') ?? search;
   const responseHeaders = {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
@@ -173,7 +160,7 @@ export default async function handle(request: Request) {
   };
 
   const store = getStore('facts');
-  const stored = await store.get(search);
+  const stored = await store.get(blobId);
   if (stored != null) {
     return new Response(simulateTokenGeneration(stored, 5, 15), { headers: responseHeaders });
   }
@@ -184,7 +171,7 @@ export default async function handle(request: Request) {
   const [streamForResponse, streamForStore] = stream.tee();
 
   // Process the cache stream in the background
-  storeResponse(store, search, streamForStore);
+  storeResponse(store, blobId, streamForStore);
 
   return new Response(streamForResponse, { headers: responseHeaders });
 }

--- a/functions/facts.ts
+++ b/functions/facts.ts
@@ -102,7 +102,7 @@ What facts can you tell me about '${search}'? I'm interested in things like the 
 - Information about name and origins
 - Dimensions (for non-spherical small bodies only)
 - Rotation facts (e.g. tidally locked or not)
-- Albedo
+- Albedo (if known)
 - Material composition (if known)
 - Density (if known)
 
@@ -111,6 +111,7 @@ I'm not interested in the following:
 - Rotation period (if known)
 - Relevant spacecraft missions and dates
 - Major satellites (if any)
+- Anything 'unknown'
 
 Format your answer as markdown bullet points, with **bolded** keys. Do not include orbital characteristics. Do not \
 preface your answer or return anything other than bullet points.

--- a/src/components/FactSheet/CelestialBodyFactSheet.tsx
+++ b/src/components/FactSheet/CelestialBodyFactSheet.tsx
@@ -47,6 +47,8 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
   const orbitalRegimePill =
     orbitalRegime != null ? <OrbitalRegimePill regime={orbitalRegime} updateSettings={updateSettings} /> : undefined;
   const wikiPill = assets?.wiki != null ? <WikiLinkPill url={assets.wiki} /> : undefined;
+  const gravity = (surfaceGravity(mass, radius) / g).toLocaleString();
+
   const bullets: Array<{ label: string; value: ReactNode }> = [
     ...(orbitalRegimePill != null ? [{ label: 'orbital regime', value: orbitalRegimePill }] : []),
     ...(wikiPill != null ? [{ label: 'learn more', value: wikiPill }] : []),
@@ -69,7 +71,9 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
       },
       { label: 'axial tilt', value: `${rotation.axialTilt.toLocaleString()}º` },
     ] : []),
-    { label: 'surface gravity', value: `${(surfaceGravity(mass, radius) / g).toLocaleString()} g` },
+    ...(Number(gravity) > 0
+      ? [{ label: 'surface gravity', value: `${(surfaceGravity(mass, radius) / g).toLocaleString()} g` }]
+      : []),
     ...(facts ?? []),
     // TODO: add simulation-dependent bullets: velocity, distance from Sun, distance from Earth
   ];

--- a/src/components/FactSheet/CelestialBodyFactSheet.tsx
+++ b/src/components/FactSheet/CelestialBodyFactSheet.tsx
@@ -35,7 +35,7 @@ export const CelestialBodyFactSheet = memo(function CelestialBodyFactSheetCompon
 }: Props) {
   const { id, name, type, mass, radius, elements, orbitalRegime, assets, facts, style } = body;
   const { wrt, semiMajorAxis, eccentricity, inclination, longitudeAscending, argumentOfPeriapsis, rotation } = elements;
-  const { data: extraFacts, isLoading } = useFactsStream(assets?.search ?? `${name}+${type}`);
+  const { data: extraFacts, isLoading } = useFactsStream(body);
   const padding = useFactSheetPadding();
   const { xs: isXsDisplay } = useDisplaySize();
 

--- a/src/hooks/queries/useFactsStream.ts
+++ b/src/hooks/queries/useFactsStream.ts
@@ -1,17 +1,20 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { readStreamResponse } from '../../lib/functions.ts';
+import { readStreamResponse, slugifyId } from '../../lib/functions.ts';
+import { CelestialBody } from '../../lib/types.ts';
 
-export function useFactsStream(search: string) {
+export function useFactsStream({ id, name, type, assets }: CelestialBody) {
   const [isStreaming, setIsStreaming] = useState(false);
   const queryClient = useQueryClient();
+  const search = assets?.search ?? `${name}+${type}`;
+  const blobId = `facts-${slugifyId(id)}`;
   const queryKey = ['GET', 'facts', search];
 
   const query = useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
       setIsStreaming(true);
-      const response = await fetch(`/api/facts?search=${encodeURIComponent(search)}`, { signal });
+      const response = await fetch(`/api/facts?${new URLSearchParams({ search, blobId })}`, { signal });
       const setData = (data: string) => queryClient.setQueryData<string>(queryKey, data);
       return await readStreamResponse(response, setIsStreaming, setData);
     },

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { initialState, itemIdAsRoute, UpdateSettings } from '../lib/state.ts';
+import { useIsTouchDevice } from './useIsTouchDevice.ts';
+import { useUrlState } from './useUrlState.ts';
+
+export function useAppState() {
+  const { center: urlCenter } = useUrlState();
+  const isTouchDevice = useIsTouchDevice();
+  const urlInitialState = { ...initialState, settings: { ...initialState.settings, center: urlCenter } };
+  const [appState, setAppState] = useState(urlInitialState);
+  const appStateRef = useRef(appState);
+  const navigate = useNavigate();
+  const { settings } = appState;
+
+  const updateSettings: UpdateSettings = useCallback(
+    update => {
+      setAppState(prev => {
+        const updated = typeof update === 'function' ? update(prev.settings) : { ...prev.settings, ...update };
+        // disable hover for touch devices; interactions don't work well
+        if (isTouchDevice) updated.hover = null;
+        const newState = { ...prev, settings: updated };
+        // set the mutable state ref (accessed by animation callback) on state update
+        appStateRef.current = newState;
+        return newState;
+      });
+    },
+    [setAppState, isTouchDevice]
+  );
+
+  const resetAppState = useCallback(() => {
+    setAppState(initialState);
+    appStateRef.current = initialState;
+    return initialState;
+  }, [updateSettings]);
+
+  // sync URL to center
+  useEffect(() => {
+    if (settings.center !== urlCenter) updateSettings({ center: urlCenter });
+  }, [urlCenter]);
+
+  // sync center back to URL when state changes are initiated by non-URL source
+  useEffect(() => {
+    if (settings.center !== urlCenter) navigate(itemIdAsRoute(settings.center));
+  }, [settings.center]);
+
+  return { appState, setAppState, appStateRef, updateSettings, resetAppState };
+}

--- a/src/hooks/useFocusItem.ts
+++ b/src/hooks/useFocusItem.ts
@@ -1,0 +1,45 @@
+import { useEffect, useMemo } from 'react';
+import { ORBITAL_REGIMES, orbitalRegimeDisplayName } from '../lib/regimes.ts';
+import { SPACECRAFT_BY_ID } from '../lib/spacecraft.ts';
+import { Settings } from '../lib/state.ts';
+import {
+  isCelestialBody,
+  isCelestialBodyId,
+  isOrbitalRegime,
+  isOrbitalRegimeId,
+  isSpacecraft,
+  isSpacecraftId,
+} from '../lib/types.ts';
+import { DEFAULT_ASTEROID_COLOR, DEFAULT_SPACECRAFT_COLOR } from '../lib/utils.ts';
+
+export function useFocusItem({ center, bodies }: Settings) {
+  const focusItem = useMemo(() => {
+    return isCelestialBodyId(center)
+      ? bodies.find(({ id }) => id === center)
+      : isOrbitalRegimeId(center)
+        ? ORBITAL_REGIMES.find(({ id }) => id === center)
+        : isSpacecraftId(center)
+          ? SPACECRAFT_BY_ID[center]
+          : undefined;
+  }, [center, JSON.stringify(bodies)]);
+
+  const focusColor = isCelestialBody(focusItem)
+    ? focusItem.style.fgColor
+    : isSpacecraft(focusItem)
+      ? DEFAULT_SPACECRAFT_COLOR
+      : DEFAULT_ASTEROID_COLOR;
+
+  useEffect(() => {
+    const name = isCelestialBody(focusItem)
+      ? (focusItem.shortName ?? focusItem.name)
+      : isOrbitalRegime(focusItem)
+        ? orbitalRegimeDisplayName(focusItem.id)
+        : isSpacecraft(focusItem)
+          ? focusItem.name
+          : undefined;
+    const namePart = name != null ? `${name} • ` : '';
+    document.title = `${namePart}Atlas of Space`;
+  }, [focusItem]);
+
+  return { focusItem, focusColor };
+}

--- a/src/lib/bodies.ts
+++ b/src/lib/bodies.ts
@@ -1366,6 +1366,29 @@ export const ERIS = celestialBodyWithDefaults({
   // TODO: add moon Dysnomia (rough orbital elements are known)
 });
 
+export const DYSNOMIA = celestialBodyWithDefaults({
+  type: CelestialBodyType.MOON,
+  name: 'Dysnomia',
+  influencedBy: [ERIS.id],
+  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
+  elements: {
+    wrt: ERIS.id,
+    epoch: julianDayToEpoch('JD2453979.0'),
+    semiMajorAxis: 37273e3,
+    eccentricity: 0.0062,
+    inclination: 78.29,
+    longitudeAscending: 126.17,
+    argumentOfPeriapsis: 180.83,
+    meanAnomaly: 0, // TODO
+  },
+  mass: 8.2e19,
+  radius: 307.5e3,
+  assets: {
+    thumbnail: 'dysnomia-thumb.jpg',
+    wiki: 'https://en.wikipedia.org/wiki/Dysnomia_(moon)',
+  },
+});
+
 export const HAUMEA = celestialBodyWithDefaults({
   type: CelestialBodyType.DWARF_PLANET,
   name: '136108 Haumea',
@@ -1726,6 +1749,7 @@ export const TRANS_NEPTUNIAN_OBJECTS: Array<CelestialBody> = [
   ORCUS,
   HAUMEA,
   ERIS,
+  DYSNOMIA,
   MAKEMAKE,
   GONGGONG,
   ARROKOTH,

--- a/src/lib/bodies.ts
+++ b/src/lib/bodies.ts
@@ -537,6 +537,7 @@ export const IDA = celestialBodyWithDefaults({
   assets: {
     thumbnail: 'ida-thumb.jpg',
     wiki: 'https://en.wikipedia.org/wiki/243_Ida',
+    search: 'Q149012',
   },
 });
 

--- a/src/lib/bodies.ts
+++ b/src/lib/bodies.ts
@@ -1366,29 +1366,6 @@ export const ERIS = celestialBodyWithDefaults({
   // TODO: add moon Dysnomia (rough orbital elements are known)
 });
 
-export const DYSNOMIA = celestialBodyWithDefaults({
-  type: CelestialBodyType.MOON,
-  name: 'Dysnomia',
-  influencedBy: [ERIS.id],
-  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
-  elements: {
-    wrt: ERIS.id,
-    epoch: julianDayToEpoch('JD2453979.0'),
-    semiMajorAxis: 37273e3,
-    eccentricity: 0.0062,
-    inclination: 78.29,
-    longitudeAscending: 126.17,
-    argumentOfPeriapsis: 180.83,
-    meanAnomaly: 0, // TODO
-  },
-  mass: 8.2e19,
-  radius: 307.5e3,
-  assets: {
-    thumbnail: 'dysnomia-thumb.jpg',
-    wiki: 'https://en.wikipedia.org/wiki/Dysnomia_(moon)',
-  },
-});
-
 export const HAUMEA = celestialBodyWithDefaults({
   type: CelestialBodyType.DWARF_PLANET,
   name: '136108 Haumea',
@@ -1410,54 +1387,6 @@ export const HAUMEA = celestialBodyWithDefaults({
   assets: {
     thumbnail: 'haumea-thumb.jpg',
     wiki: 'https://en.wikipedia.org/wiki/Haumea',
-  },
-});
-
-export const HIIAKA = celestialBodyWithDefaults({
-  type: CelestialBodyType.MOON,
-  name: "Hi'iaka",
-  influencedBy: [HAUMEA.id],
-  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
-  elements: {
-    wrt: HAUMEA.id,
-    source: 'https://arxiv.org/pdf/0903.4213',
-    epoch: julianDayToEpoch('JD2454615.0'),
-    eccentricity: 0.0513,
-    semiMajorAxis: 49880e3,
-    inclination: 126.356,
-    longitudeAscending: 206.766,
-    argumentOfPeriapsis: 154.1,
-    meanAnomaly: 152.8,
-  },
-  mass: 17.9e18,
-  radius: 155e3,
-  assets: {
-    thumbnail: 'hi-iaka-thumb.jpg',
-    wiki: 'https://en.wikipedia.org/wiki/Moons_of_Haumea',
-  },
-});
-
-export const NAMAKA = celestialBodyWithDefaults({
-  type: CelestialBodyType.MOON,
-  name: 'Namaka',
-  influencedBy: [HAUMEA.id],
-  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
-  elements: {
-    wrt: HAUMEA.id,
-    source: 'https://arxiv.org/pdf/0903.4213',
-    epoch: julianDayToEpoch('JD2454615.0'),
-    eccentricity: 0.249,
-    semiMajorAxis: 25657e3,
-    inclination: 113.013,
-    longitudeAscending: 205.016,
-    argumentOfPeriapsis: 178.9,
-    meanAnomaly: 178.5,
-  },
-  mass: 1.79e18,
-  radius: 85e3,
-  assets: {
-    thumbnail: 'namaka-thumb.jpg',
-    wiki: 'https://en.wikipedia.org/wiki/Moons_of_Haumea',
   },
 });
 
@@ -1796,10 +1725,7 @@ export const TRANS_NEPTUNIAN_OBJECTS: Array<CelestialBody> = [
   SEDNA,
   ORCUS,
   HAUMEA,
-  HIIAKA,
-  NAMAKA,
   ERIS,
-  DYSNOMIA,
   MAKEMAKE,
   GONGGONG,
   ARROKOTH,

--- a/src/lib/bodies.ts
+++ b/src/lib/bodies.ts
@@ -1413,6 +1413,54 @@ export const HAUMEA = celestialBodyWithDefaults({
   },
 });
 
+export const HIIAKA = celestialBodyWithDefaults({
+  type: CelestialBodyType.MOON,
+  name: "Hi'iaka",
+  influencedBy: [HAUMEA.id],
+  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
+  elements: {
+    wrt: HAUMEA.id,
+    source: 'https://arxiv.org/pdf/0903.4213',
+    epoch: julianDayToEpoch('JD2454615.0'),
+    eccentricity: 0.0513,
+    semiMajorAxis: 49880e3,
+    inclination: 126.356,
+    longitudeAscending: 206.766,
+    argumentOfPeriapsis: 154.1,
+    meanAnomaly: 152.8,
+  },
+  mass: 17.9e18,
+  radius: 155e3,
+  assets: {
+    thumbnail: 'hi-iaka-thumb.jpg',
+    wiki: 'https://en.wikipedia.org/wiki/Moons_of_Haumea',
+  },
+});
+
+export const NAMAKA = celestialBodyWithDefaults({
+  type: CelestialBodyType.MOON,
+  name: 'Namaka',
+  influencedBy: [HAUMEA.id],
+  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
+  elements: {
+    wrt: HAUMEA.id,
+    source: 'https://arxiv.org/pdf/0903.4213',
+    epoch: julianDayToEpoch('JD2454615.0'),
+    eccentricity: 0.249,
+    semiMajorAxis: 25657e3,
+    inclination: 113.013,
+    longitudeAscending: 205.016,
+    argumentOfPeriapsis: 178.9,
+    meanAnomaly: 178.5,
+  },
+  mass: 1.79e18,
+  radius: 85e3,
+  assets: {
+    thumbnail: 'namaka-thumb.jpg',
+    wiki: 'https://en.wikipedia.org/wiki/Moons_of_Haumea',
+  },
+});
+
 export const MAKEMAKE = celestialBodyWithDefaults({
   type: CelestialBodyType.DWARF_PLANET,
   name: '136472 Makemake',
@@ -1748,6 +1796,8 @@ export const TRANS_NEPTUNIAN_OBJECTS: Array<CelestialBody> = [
   SEDNA,
   ORCUS,
   HAUMEA,
+  HIIAKA,
+  NAMAKA,
   ERIS,
   DYSNOMIA,
   MAKEMAKE,


### PR DESCRIPTION
Omit spacecraft and satellite information, as this is provided in a more visual format in other sections in the fact sheet.

Also extract app state management and model management to hooks, to hopefully make things easier to maintain, with less splicing going on in the root `SolarSystem` component.