### PR TITLE
Add Eris, Haumea moons

### DIFF
--- a/src/lib/bodies.ts
+++ b/src/lib/bodies.ts
@@ -1366,6 +1366,29 @@ export const ERIS = celestialBodyWithDefaults({
   // TODO: add moon Dysnomia (rough orbital elements are known)
 });
 
+export const DYSNOMIA = celestialBodyWithDefaults({
+  type: CelestialBodyType.MOON,
+  name: 'Dysnomia',
+  influencedBy: [ERIS.id],
+  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
+  elements: {
+    wrt: ERIS.id,
+    epoch: julianDayToEpoch('JD2453979.0'),
+    semiMajorAxis: 37273e3,
+    eccentricity: 0.0062,
+    inclination: 78.29,
+    longitudeAscending: 126.17,
+    argumentOfPeriapsis: 180.83,
+    meanAnomaly: 0, // TODO
+  },
+  mass: 8.2e19,
+  radius: 307.5e3,
+  assets: {
+    thumbnail: 'dysnomia-thumb.jpg',
+    wiki: 'https://en.wikipedia.org/wiki/Dysnomia_(moon)',
+  },
+});
+
 export const HAUMEA = celestialBodyWithDefaults({
   type: CelestialBodyType.DWARF_PLANET,
   name: '136108 Haumea',
@@ -1387,6 +1410,54 @@ export const HAUMEA = celestialBodyWithDefaults({
   assets: {
     thumbnail: 'haumea-thumb.jpg',
     wiki: 'https://en.wikipedia.org/wiki/Haumea',
+  },
+});
+
+export const HIIAKA = celestialBodyWithDefaults({
+  type: CelestialBodyType.MOON,
+  name: "Hi'iaka",
+  influencedBy: [HAUMEA.id],
+  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
+  elements: {
+    wrt: HAUMEA.id,
+    source: 'https://arxiv.org/pdf/0903.4213',
+    epoch: julianDayToEpoch('JD2454615.0'),
+    eccentricity: 0.0513,
+    semiMajorAxis: 49880e3,
+    inclination: 126.356,
+    longitudeAscending: 206.766,
+    argumentOfPeriapsis: 154.1,
+    meanAnomaly: 152.8,
+  },
+  mass: 17.9e18,
+  radius: 155e3,
+  assets: {
+    thumbnail: 'hi-iaka-thumb.jpg',
+    wiki: 'https://en.wikipedia.org/wiki/Moons_of_Haumea',
+  },
+});
+
+export const NAMAKA = celestialBodyWithDefaults({
+  type: CelestialBodyType.MOON,
+  name: 'Namaka',
+  influencedBy: [HAUMEA.id],
+  orbitalRegime: OrbitalRegimeId.KUIPER_BELT,
+  elements: {
+    wrt: HAUMEA.id,
+    source: 'https://arxiv.org/pdf/0903.4213',
+    epoch: julianDayToEpoch('JD2454615.0'),
+    eccentricity: 0.249,
+    semiMajorAxis: 25657e3,
+    inclination: 113.013,
+    longitudeAscending: 205.016,
+    argumentOfPeriapsis: 178.9,
+    meanAnomaly: 178.5,
+  },
+  mass: 1.79e18,
+  radius: 85e3,
+  assets: {
+    thumbnail: 'namaka-thumb.jpg',
+    wiki: 'https://en.wikipedia.org/wiki/Moons_of_Haumea',
   },
 });
 
@@ -1725,7 +1796,10 @@ export const TRANS_NEPTUNIAN_OBJECTS: Array<CelestialBody> = [
   SEDNA,
   ORCUS,
   HAUMEA,
+  HIIAKA,
+  NAMAKA,
   ERIS,
+  DYSNOMIA,
   MAKEMAKE,
   GONGGONG,
   ARROKOTH,


### PR DESCRIPTION
Opening as draft to keep track of these changes.

The Kuiper belt dwarf planets Eris and Haumea have known moons. These are known well enough to have orbital parameters, but not quite well enough to have these orbital parameters yield steady orbits when run through the app's physics simulation. Eris' Dysnomia is more-or-less OK but can get unstable after a long time has passed; Haumea's Namaka and Hi'iaka are highly unstable from the get-go.

https://github.com/user-attachments/assets/d5943734-44bc-4af9-9fa4-afeb5c81ad96

To add these with confidence, may need to add an flag for a body to opt out of physical simulation, and instead run like clockwork progressing along the orbital ellipse. Not sure what I'll do here.