### PR TITLE
Disable streaming of summaries in cards

### DIFF
--- a/src/components/Controls/HelpModal.tsx
+++ b/src/components/Controls/HelpModal.tsx
@@ -38,7 +38,7 @@ import { useModifierKey } from '../../hooks/useModifierKey.ts';
 import { SPACECRAFT } from '../../lib/data/spacecraft.ts';
 import { Settings } from '../../lib/state.ts';
 import { CelestialBody, isCelestialBody, Spacecraft } from '../../lib/types.ts';
-import { BodyCard } from '../FactSheet/BodyCard.tsx';
+import { CelestialBodyCard } from '../FactSheet/CelestialBodyCard.tsx';
 import { SpacecraftCard } from '../FactSheet/Spacecraft/SpacecraftCard.tsx';
 import { iconSize } from './constants.ts';
 
@@ -103,7 +103,7 @@ export function HelpModal({ isOpen, onClose, settings, updateSettings }: Props) 
 
   const sampleItemCards = sampleItems.map(item =>
     isCelestialBody(item) ? (
-      <BodyCard key={item.id} body={item} onClick={() => onCardClick(item)} />
+      <CelestialBodyCard key={item.id} body={item} onClick={() => onCardClick(item)} />
     ) : (
       <SpacecraftCard key={item.id} spacecraft={item} onClick={() => onCardClick(item)} compact />
     )

--- a/src/components/FactSheet/CelestialBodyCard.tsx
+++ b/src/components/FactSheet/CelestialBodyCard.tsx
@@ -11,8 +11,12 @@ type Props = {
   onClick: () => void;
   onHover?: (hovered: boolean) => void;
 };
-export function BodyCard({ body, onClick, onHover }: Props) {
-  const { data: summary, isLoading } = useSummaryStream({ item: body, type: FocusItemType.CELESTIAL_BODY });
+export function CelestialBodyCard({ body, onClick, onHover }: Props) {
+  const { data: summary, isLoading } = useSummaryStream({
+    item: body,
+    type: FocusItemType.CELESTIAL_BODY,
+    stream: false,
+  });
   return (
     <Paper
       className={styles.Card}

--- a/src/components/FactSheet/MajorSatellites.tsx
+++ b/src/components/FactSheet/MajorSatellites.tsx
@@ -4,7 +4,7 @@ import { useFactSheetPadding } from '../../hooks/useFactSheetPadding.ts';
 import { UpdateSettings } from '../../lib/state.ts';
 import { CelestialBody, CelestialBodyType } from '../../lib/types.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
-import { BodyCard } from './BodyCard.tsx';
+import { CelestialBodyCard } from './CelestialBodyCard.tsx';
 
 const MAJOR_SATELLITE_TYPES = new Set([CelestialBodyType.PLANET, CelestialBodyType.MOON]);
 
@@ -36,7 +36,7 @@ export function MajorSatellites({ body, bodies, updateSettings }: Props) {
     <Stack gap="xs" {...padding}>
       <Title order={5}>Major {satelliteTypeDisplayName}</Title>
       {satellites.map((satellite, i) => (
-        <BodyCard
+        <CelestialBodyCard
           key={`${satellite.name}-${i}`}
           body={satellite}
           onClick={() => updateSettings({ center: satellite.id, hover: null })}

--- a/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
+++ b/src/components/FactSheet/OrbitalRegimeFactSheet.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../lib/types.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
 import { AddSmallBodyButton } from './AddSmallBodyButton.tsx';
-import { BodyCard } from './BodyCard.tsx';
+import { CelestialBodyCard } from './CelestialBodyCard.tsx';
 import { FactSheetSummary } from './FactSheetSummary.tsx';
 import { FactSheetTitle } from './FactSheetTitle.tsx';
 import { OtherRegimes } from './OtherRegimes.tsx';
@@ -76,7 +76,7 @@ export const OrbitalRegimeFactSheet = memo(function OrbitalRegimeFactSheetCompon
             <Stack gap="xs" key={`${type}-${i}`}>
               <Title order={5}>{celestialBodyTypeName(type as CelestialBodyType, true)}</Title>
               {bodies.map((body, j) => (
-                <BodyCard
+                <CelestialBodyCard
                   key={`${body.name}-${j}`}
                   body={body}
                   onClick={() => updateSettings({ center: body.id })}

--- a/src/components/FactSheet/ParentBody.tsx
+++ b/src/components/FactSheet/ParentBody.tsx
@@ -4,7 +4,7 @@ import { useFactSheetPadding } from '../../hooks/useFactSheetPadding.ts';
 import { Settings } from '../../lib/state.ts';
 import { CelestialBody, CelestialBodyType } from '../../lib/types.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
-import { BodyCard } from './BodyCard.tsx';
+import { CelestialBodyCard } from './CelestialBodyCard.tsx';
 
 type Props = {
   body: CelestialBody;
@@ -20,7 +20,7 @@ export function ParentBody({ body, bodies, updateSettings }: Props) {
   return parentBody != null ? (
     <Stack gap="xs" {...padding}>
       <Title order={5}>Parent {celestialBodyTypeName(parentBody.type)}</Title>
-      <BodyCard
+      <CelestialBodyCard
         body={parentBody}
         onClick={() => updateSettings({ center: parentBody.id, hover: null })}
         onHover={hovered => updateSettings({ hover: hovered ? parentBody.id : null })}

--- a/src/components/FactSheet/Spacecraft/MissionEndCard.tsx
+++ b/src/components/FactSheet/Spacecraft/MissionEndCard.tsx
@@ -11,7 +11,11 @@ type Props = {
   spacecraft: Spacecraft;
 };
 export function MissionEndCard({ spacecraft }: Props) {
-  const { data: summary, isLoading } = useSpacecraftSummaryStream({ type: SpacecraftSummaryType.END, spacecraft });
+  const { data: summary, isLoading } = useSpacecraftSummaryStream({
+    type: SpacecraftSummaryType.END,
+    spacecraft,
+    stream: false,
+  });
   return (
     <Paper p="xs" withBorder>
       <Group gap={0} align="baseline">

--- a/src/components/FactSheet/Spacecraft/MissionTimelineCard.tsx
+++ b/src/components/FactSheet/Spacecraft/MissionTimelineCard.tsx
@@ -21,6 +21,7 @@ export function MissionTimelineCard({ body, spacecraft, visit, updateSettings }:
     spacecraft,
     body,
     visit,
+    stream: false,
   });
   return (
     <Paper

--- a/src/components/FactSheet/Spacecraft/SpacecraftCard.tsx
+++ b/src/components/FactSheet/Spacecraft/SpacecraftCard.tsx
@@ -26,7 +26,7 @@ export function SpacecraftCard({ spacecraft, body, regime, onClick, compact = fa
       : regime != null
         ? { type: SpacecraftSummaryType.REGIME as const, spacecraft, regime }
         : { type: SpacecraftSummaryType.SUMMARY as const, spacecraft };
-  const { data: summary, isLoading } = useSpacecraftSummaryStream(summaryParams);
+  const { data: summary, isLoading } = useSpacecraftSummaryStream({ ...summaryParams, stream: false });
 
   const visitPastTense = visit != null && visit.start < new Date();
   // prettier-ignore

--- a/src/hooks/queries/useSpacecraftSummaryStream.ts
+++ b/src/hooks/queries/useSpacecraftSummaryStream.ts
@@ -17,18 +17,19 @@ type Params =
   | { type: SpacecraftSummaryType.VISIT; spacecraft: Spacecraft; body: CelestialBody; visit: SpacecraftVisit }
   | { type: SpacecraftSummaryType.REGIME; spacecraft: Spacecraft; regime: OrbitalRegime }
   | { type: SpacecraftSummaryType.END; spacecraft: Spacecraft };
-export function useSpacecraftSummaryStream(params: Params) {
+export function useSpacecraftSummaryStream({ stream = true, ...params }: Params & { stream?: boolean }) {
   const [isStreaming, setIsStreaming] = useState(false);
   const search = getSearch(params);
   const blobId = getBlobId(params);
   const queryClient = useQueryClient();
-  const queryKey = ['GET', 'facts', blobId];
+  const queryKey = ['GET', 'visit', blobId];
 
   const query = useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
       setIsStreaming(true);
-      const response = await fetch(`/api/visit?${new URLSearchParams({ search, blobId })}`, { signal });
+      const searchParams = new URLSearchParams({ search, blobId, stream: String(stream) });
+      const response = await fetch(`/api/visit?${searchParams}`, { signal });
       const setData = (data: string) => queryClient.setQueryData<string>(queryKey, data);
       return await readStreamResponse(response, setIsStreaming, setData);
     },

--- a/src/hooks/queries/useSummaryStream.ts
+++ b/src/hooks/queries/useSummaryStream.ts
@@ -7,17 +7,18 @@ import { CelestialBodyType } from '../../lib/types.ts';
 import { celestialBodyTypeName } from '../../lib/utils.ts';
 import { FocusItemType, TypedFocusItem } from '../useFocusItem.ts';
 
-export function useSummaryStream(props: TypedFocusItem) {
+export function useSummaryStream({ stream = true, ...props }: TypedFocusItem & { stream?: boolean }) {
   const search = useMemo(() => getSearch(props), [JSON.stringify(props)]);
   const [isStreaming, setIsStreaming] = useState(false);
   const queryClient = useQueryClient();
-  const queryKey = ['GET', 'facts', search];
+  const queryKey = ['GET', 'summary', search];
 
   const query = useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
       setIsStreaming(true);
-      const response = await fetch(`/api/summary?search=${encodeURIComponent(search)}`, { signal });
+      const searchParams = new URLSearchParams({ search, stream: String(stream) });
+      const response = await fetch(`/api/summary?${searchParams}`, { signal });
       const setData = (data: string) => queryClient.setQueryData<string>(queryKey, data);
       return await readStreamResponse(response, setIsStreaming, setData);
     },


### PR DESCRIPTION
Reduce jumpiness from streaming in summaries that are displayed in cards. Keep it in other places, namely the main summary shown in a fact sheet, and the facts themselves. May reduce further in the future. My hope is to get the core web vitals green.