### PR TITLE
Improve deferred texture loading

### DIFF
--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -107,10 +107,11 @@ export class KeplerianBody extends KinematicBody {
 
     const baseRadius = this.body.radius / metersPerPx;
     const bodyRadius = this.hovered ? baseRadius * HOVER_SCALE_FACTOR : baseRadius;
-    if (bodyRadius < this.dotRadius) {
-      if (this.shouldDrawDot(metersPerPx)) drawDotAtLocation(ctx, textColor, bodyPx, this.dotRadius);
-    } else {
-      this.sphere.ensureTextureLoaded(); // since the body is visible, ensure that its texture is loaded
+    if (bodyRadius < this.dotRadius && this.shouldDrawDot(metersPerPx)) {
+      drawDotAtLocation(ctx, textColor, bodyPx, this.dotRadius);
+    }
+    if (1.5 * bodyRadius >= this.dotRadius) {
+      this.sphere.ensureTextureLoaded(); // since the body is close to being visible, ensure that its texture is loaded
     }
 
     const fontSizePx = this.labelFontSize(metersPerPx);

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -107,13 +107,9 @@ export class KeplerianBody extends KinematicBody {
 
     const baseRadius = this.body.radius / metersPerPx;
     const bodyRadius = this.hovered ? baseRadius * HOVER_SCALE_FACTOR : baseRadius;
-    if (bodyRadius < this.dotRadius && this.shouldDrawDot(metersPerPx)) {
-      drawDotAtLocation(ctx, textColor, bodyPx, this.dotRadius);
-    }
-    if (bodyRadius >= this.dotRadius) {
-      console.log(
-        `loading texture for ${this.body.id}, body radius ${bodyRadius}, dot radius ${this.dotRadius}, should draw dot ${this.shouldDrawDot(metersPerPx)}`
-      );
+    if (bodyRadius < this.dotRadius) {
+      if (this.shouldDrawDot(metersPerPx)) drawDotAtLocation(ctx, textColor, bodyPx, this.dotRadius);
+    } else {
       this.sphere.ensureTextureLoaded(); // since the body is visible, ensure that its texture is loaded
     }
 

--- a/src/lib/model/KeplerianBody.ts
+++ b/src/lib/model/KeplerianBody.ts
@@ -109,7 +109,11 @@ export class KeplerianBody extends KinematicBody {
     const bodyRadius = this.hovered ? baseRadius * HOVER_SCALE_FACTOR : baseRadius;
     if (bodyRadius < this.dotRadius && this.shouldDrawDot(metersPerPx)) {
       drawDotAtLocation(ctx, textColor, bodyPx, this.dotRadius);
-    } else {
+    }
+    if (bodyRadius >= this.dotRadius) {
+      console.log(
+        `loading texture for ${this.body.id}, body radius ${bodyRadius}, dot radius ${this.dotRadius}, should draw dot ${this.shouldDrawDot(metersPerPx)}`
+      );
       this.sphere.ensureTextureLoaded(); // since the body is visible, ensure that its texture is loaded
     }
 


### PR DESCRIPTION
The previous dependence on `this.shouldDrawDot` meant that moons were loaded eagerly. This was bad because the Luna texture is >1MB!